### PR TITLE
feat: add Invivo PDF upload and blood analysis parsing (RU/KZ)

### DIFF
--- a/backend/app/services/invivo_blood_parser.py
+++ b/backend/app/services/invivo_blood_parser.py
@@ -1,0 +1,106 @@
+"""
+Parser for Invivo (RU/KZ) blood analysis PDFs.
+"""
+
+from typing import Dict, List, Optional, Tuple
+import re
+
+ResultEntry = Dict[str, float | str | None]
+ParsedResult = Dict[str, ResultEntry]
+
+ALIASES: Dict[str, List[str]] = {
+    "hemoglobin": ["hemoglobin", "гемоглобин"],
+    "rbc": ["rbc", "эритроциты", "эритроциттер"],
+    "wbc": ["wbc", "лейкоциты", "лейкоциттер"],
+    "platelets": ["platelets", "plt", "тромбоциты", "тромбоциттер"],
+    "glucose": ["glucose", "глюкоза"],
+    "cholesterol": ["cholesterol", "холестерин"],
+    "alt": ["alt", "алт"],
+    "ast": ["ast", "аст"],
+    "creatinine": ["creatinine", "креатинин"],
+    "esr": ["esr", "соэ", "этж"],
+}
+
+
+def _empty_result() -> ParsedResult:
+    return {
+        key: {"value": None, "unit": None, "confidence": 0.0}
+        for key in ALIASES.keys()
+    }
+
+
+def _parse_value_and_unit(line: str) -> Tuple[Optional[float], Optional[str]]:
+    value_match = re.search(r"(\d+(?:[.,]\d+)?)", line)
+    if not value_match:
+        return None, None
+
+    value_str = value_match.group(1).replace(",", ".")
+    try:
+        value = float(value_str)
+    except ValueError:
+        value = None
+
+    unit_match = re.search(
+        r"\d+(?:[.,]\d+)?\s*([a-zа-яёµ/%\^\d\*\/\.]+)",
+        line,
+        flags=re.IGNORECASE,
+    )
+    unit = unit_match.group(1).strip() if unit_match and unit_match.group(1) else None
+    return value, unit
+
+
+def _set_result(result: ParsedResult, key: str, value: Optional[float], unit: Optional[str], confidence: float) -> None:
+    current = result[key]
+    if value is None:
+        return
+    if current["confidence"] < confidence:
+        result[key] = {"value": value, "unit": unit, "confidence": confidence}
+
+
+def parse_invivo_blood(text: str) -> ParsedResult:
+    """
+    Parse Invivo blood analysis text (RU/KZ) into structured markers.
+    """
+    normalized_text = text or ""
+    result = _empty_result()
+
+    # ALT/AST combined pattern (e.g., "АЛТ/АСТ 23/18")
+    alt_ast_pattern = re.compile(
+        r"(?:алт|alt)\s*/\s*(?:аст|ast)[^\d]*(?P<alt>\d+(?:[.,]\d+)?)\s*/\s*(?P<ast>\d+(?:[.,]\d+)?)(?:\s*(?P<unit>[a-zа-яё/%\^\d\*\/\.]+))?",
+        flags=re.IGNORECASE,
+    )
+    for match in alt_ast_pattern.finditer(normalized_text):
+        unit = match.group("unit") or None
+        alt_value = float(match.group("alt").replace(",", "."))
+        ast_value = float(match.group("ast").replace(",", "."))
+        _set_result(result, "alt", alt_value, unit, 1.0)
+        _set_result(result, "ast", ast_value, unit, 1.0)
+
+    lines = [line.strip() for line in normalized_text.splitlines() if line.strip()]
+    alias_lower = {k: [alias.lower() for alias in v] for k, v in ALIASES.items()}
+
+    # Line-based parsing (higher confidence)
+    for line in lines:
+        line_lower = line.lower()
+        for key, aliases in alias_lower.items():
+            if any(alias in line_lower for alias in aliases):
+                value, unit = _parse_value_and_unit(line)
+                _set_result(result, key, value, unit, 1.0)
+
+    # Fallback search across whole text (lower confidence)
+    for key, aliases in alias_lower.items():
+        if result[key]["confidence"] > 0:
+            continue
+        alias_regex = "|".join(re.escape(a) for a in aliases)
+        pattern = re.compile(
+            rf"(?:{alias_regex})[^\d]*(\d+(?:[.,]\d+)?)(?:\s*([a-zа-яё/%\^\d\*\/\.]+))?",
+            flags=re.IGNORECASE,
+        )
+        match = pattern.search(normalized_text)
+        if not match:
+            continue
+        value = float(match.group(1).replace(",", "."))
+        unit = match.group(2).strip() if match.group(2) else None
+        _set_result(result, key, value, unit, 0.7)
+
+    return result

--- a/backend/app/services/pdf_parser.py
+++ b/backend/app/services/pdf_parser.py
@@ -1,0 +1,66 @@
+"""
+PDF text extraction and normalization utilities.
+"""
+
+from io import BytesIO
+import re
+from typing import List
+
+import pdfplumber
+
+try:
+    import fitz  # PyMuPDF
+except ImportError:  # pragma: no cover - fallback may be unavailable in tests
+    fitz = None  # type: ignore
+
+
+def extract_text_from_pdf(file_bytes: bytes) -> str:
+    """
+    Extract text from PDF using pdfplumber with PyMuPDF as fallback.
+    """
+    text_parts: List[str] = []
+    try:
+        with pdfplumber.open(BytesIO(file_bytes)) as pdf:
+            for page in pdf.pages:
+                page_text = page.extract_text() or ""
+                if page_text:
+                    text_parts.append(page_text)
+    except Exception:
+        # Extraction errors should not break the fallback path
+        pass
+
+    extracted = "\n".join(text_parts).strip()
+    if extracted or fitz is None:
+        return extracted
+
+    fallback_parts: List[str] = []
+    try:
+        with fitz.open(stream=file_bytes, filetype="pdf") as doc:  # type: ignore
+            for page in doc:
+                page_text = page.get_text("text") or ""
+                if page_text:
+                    fallback_parts.append(page_text)
+    except Exception:
+        return extracted
+
+    return "\n".join(fallback_parts).strip()
+
+
+def normalize_text(text: str) -> str:
+    """
+    Normalize extracted text to simplify parsing.
+    - remove carriage returns
+    - merge hyphenated line breaks (a-\nb -> ab)
+    - collapse excessive spaces
+    - convert decimal comma to dot for digit patterns
+    """
+    if not text:
+        return ""
+
+    normalized = text.replace("\r", "")
+    normalized = re.sub(r"(\w)-\n(\w)", r"\1\2", normalized)
+    normalized = normalized.replace("\t", " ")
+    normalized = re.sub(r"[ ]{2,}", " ", normalized)
+    normalized = re.sub(r"(?P<int>\d+),(?P<dec>\d+)", r"\g<int>.\g<dec>", normalized)
+    normalized = re.sub(r"\n{3,}", "\n\n", normalized).strip()
+    return normalized

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -37,9 +37,10 @@ opencv-python-headless==4.10.0.84
 # Utils
 python-dotenv==1.0.1
 redis==5.2.1
+pdfplumber==0.11.4
+PyMuPDF==1.24.10
 
 # Development
 pytest==8.3.4
 pytest-asyncio==0.25.0
-
 

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for backend services."""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+
+# Ensure backend package is importable during tests
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))

--- a/backend/tests/test_blood_upload_pdf.py
+++ b/backend/tests/test_blood_upload_pdf.py
@@ -1,0 +1,43 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.api.endpoints import blood
+
+
+client = TestClient(app)
+
+
+def test_upload_pdf_returns_parsed_markers(monkeypatch):
+    sample_text = "Гемоглобин 140 г/л\nАЛТ/АСТ 20/18"
+    monkeypatch.setattr(blood, "extract_text_from_pdf", lambda _: sample_text)
+
+    response = client.post(
+        "/api/v1/services/blood/upload-pdf",
+        files={"file": ("test.pdf", b"dummy", "application/pdf")},
+        data={"patient_id": "patient-123"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["patientId"] == "patient-123"
+    assert payload["extracted"]["hemoglobin"]["value"] == 140.0
+    assert payload["extracted"]["alt"]["value"] == 20.0
+    assert payload["extracted"]["ast"]["value"] == 18.0
+    assert "hemoglobin" not in payload["missing"]
+    assert "alt" not in payload["missing"]
+    assert "ast" not in payload["missing"]
+    assert payload["rawTextLength"] == len(sample_text)
+
+
+def test_upload_pdf_without_text_returns_422(monkeypatch):
+    monkeypatch.setattr(blood, "extract_text_from_pdf", lambda _: "")
+
+    response = client.post(
+        "/api/v1/services/blood/upload-pdf",
+        files={"file": ("test.pdf", b"dummy", "application/pdf")},
+        data={"patient_id": "p-1"},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "PDF contains no extractable text. OCR is not supported."

--- a/backend/tests/test_invivo_blood_parser.py
+++ b/backend/tests/test_invivo_blood_parser.py
@@ -1,0 +1,44 @@
+from app.services.invivo_blood_parser import parse_invivo_blood
+
+
+def test_parse_invivo_ru_with_combined_alt_ast():
+    text = (
+        "Гемоглобин 145 г/л\n"
+        "Эритроциты 4,8 10^12/л\n"
+        "АЛТ/АСТ 23/18\n"
+        "СОЭ 12 мм/ч\n"
+    )
+
+    result = parse_invivo_blood(text)
+
+    assert result["hemoglobin"]["value"] == 145.0
+    assert result["hemoglobin"]["unit"] == "г/л"
+    assert result["hemoglobin"]["confidence"] == 1.0
+
+    assert result["rbc"]["value"] == 4.8
+    assert result["rbc"]["unit"] == "10^12/л"
+
+    assert result["alt"]["value"] == 23.0
+    assert result["ast"]["value"] == 18.0
+
+    assert result["esr"]["value"] == 12.0
+    assert result["esr"]["unit"] == "мм/ч"
+
+
+def test_parse_invivo_kz_aliases_and_commas():
+    text = (
+        "Эритроциттер 4,6 10^12/л\n"
+        "Лейкоциттер 7,2 10^9/л\n"
+        "ALT 30\n"
+        "AST 18\n"
+    )
+
+    result = parse_invivo_blood(text)
+
+    assert result["rbc"]["value"] == 4.6
+    assert result["wbc"]["value"] == 7.2
+    assert result["alt"]["value"] == 30.0
+    assert result["ast"]["value"] == 18.0
+
+    for key in ["rbc", "wbc", "alt", "ast"]:
+        assert result[key]["confidence"] == 1.0


### PR DESCRIPTION
- Added PDF text extraction service (pdfplumber + PyMuPDF fallback)
- Implemented Invivo blood analysis parser (RU/KZ/EN aliases, ALT/AST split)
- Added POST /api/v1/blood/upload-pdf endpoint
- Added unit tests for parser and upload endpoint
- Updated backend dependencies

Notes:
- /blood/analyze is still a mock, reused only for compatibility
- DB persistence intentionally left as TODO (no active SQLAlchemy session layer yet)
- Tests require backend requirements installed (pytest, fastapi, etc.)
