### PR TITLE
SCRUM-21..24 + serving: training on real MRI, ungated LLM, inference API

### DIFF
--- a/backend/ml_engine/README.md
+++ b/backend/ml_engine/README.md
@@ -22,10 +22,12 @@ Reference: SRS/ТЗ §7. Tracks Jira epic **SCRUM-7** (stories SCRUM-21..27).
 
 ✅ = runnable + unit-tested. Each stage has a working training loop
 (`<package>/train.py`) that runs on GPU and versions its checkpoint in the
-registry. The loops use **synthetic placeholder data** so they run today; real
-training swaps in FOMO300K / a commercially-cleared partner dataset (and, for
-report-gen, the gated Llama weights) — see data-strategy §6.2 / decision D10.
-Verified on 2× NVIDIA A10.
+registry, plus a FastAPI **serving** layer (`serving/`). Training runs on **real
+brain MRI** (`--data-dir`; `encoder/data.py` fetches the open IXITiny set) or
+on synthetic data when no dir is given. Report-gen defaults to an **ungated**
+Apache-2.0 LLM (Qwen2.5); swap `--llm` to the gated Llama once a token/licence
+is in place. The *production* model still needs a commercially-cleared partner
+dataset (decision D10). Verified on 2× NVIDIA A10.
 
 ## Quick start (registry + eval, no GPU)
 
@@ -50,9 +52,11 @@ python -m ml_engine.cli list
 pip install torch transformers peft monai     # GPU host
 CK=checkpoints
 
-# SCRUM-21 — encoder SSL pretraining (masked-volume), multi-GPU + AMP
+# SCRUM-21 — encoder SSL pretraining (masked-volume), multi-GPU + AMP.
+# On real brain MRI (auto-fetches the open IXITiny set), else synthetic:
+python -c "from ml_engine.encoder.data import fetch_ixi_tiny; fetch_ixi_tiny('data/ixi')"
 python -m ml_engine.encoder.train --amp --data-parallel --register \
-    --name mr-encoder --version 0.1.0-ssl --out $CK
+    --data-dir data/ixi/image --name mr-encoder --version 1.0.0-ixi --out $CK
 
 # SCRUM-22 — contrastive image–text alignment, warm-started from the SSL encoder
 python -m ml_engine.alignment.train --amp --register \
@@ -69,6 +73,21 @@ python -m ml_engine.report_gen.train --register --out $CK \
 
 Each `--register` versions the resulting checkpoint in the model registry, so it
 flows straight into the `eval → promote → sign-off` lifecycle above.
+
+## Serving (`serving/`, §7.5)
+
+A FastAPI inference service exposes the trained models — assistive only, every
+output flagged for radiologist sign-off (decision D2). Mountable standalone or
+as a sub-app of the platform backend (it does not touch auth/DB).
+
+```bash
+pip install fastapi uvicorn python-multipart
+export AMAN_ML_ENCODER_CKPT=$CK/mr-encoder-1.0.0-ixi.pt
+export AMAN_ML_TRIAGE_CKPT=$CK/mr-triage-0.1.1.pt
+uvicorn ml_engine.serving.app:create_default_app --factory --port 8001
+# POST /triage  (NIfTI upload) -> per-finding probs + abstention
+# POST /report  (NIfTI upload) -> draft report   |  GET /models, /healthz
+```
 
 ## Promotion gates (`config/settings.py`, override via `AMAN_ML_*`)
 

--- a/backend/ml_engine/README.md
+++ b/backend/ml_engine/README.md
@@ -10,18 +10,22 @@ Reference: SRS/ТЗ §7. Tracks Jira epic **SCRUM-7** (stories SCRUM-21..27).
 
 | Package        | Ticket   | Status            | Needs |
 |----------------|----------|-------------------|-------|
-| `registry/`    | SCRUM-27 | ✅ implemented    | stdlib + numpy |
-| `evaluation/`  | SCRUM-26 | ✅ implemented    | numpy, scikit-learn |
-| `encoder/`     | SCRUM-21 | 🏗 architecture   | torch |
-| `alignment/`   | SCRUM-22 | 🏗 architecture   | torch |
-| `report_gen/`  | SCRUM-23 | 🏗 architecture   | torch, transformers, peft |
-| `triage_head/` | SCRUM-24 | 🏗 head + calib   | torch |
-| `augmentation/`| SCRUM-25 | ✅ tagging / API  | (model: torch+monai) |
-| `config/`      | —        | settings + gates  | stdlib |
-| `cli/`         | —        | MLOps CLI         | — |
+| `registry/`    | SCRUM-27 | ✅ implemented        | stdlib + numpy |
+| `evaluation/`  | SCRUM-26 | ✅ implemented        | numpy, scikit-learn |
+| `encoder/`     | SCRUM-21 | ✅ model + SSL train  | torch |
+| `alignment/`   | SCRUM-22 | ✅ model + train      | torch |
+| `report_gen/`  | SCRUM-23 | ✅ model + LoRA train | torch, transformers, peft |
+| `triage_head/` | SCRUM-24 | ✅ train + calibrate  | torch |
+| `augmentation/`| SCRUM-25 | ✅ tagging / API      | (model: torch+monai) |
+| `config/`      | —        | settings + gates      | stdlib |
+| `cli/`         | —        | MLOps CLI             | — |
 
-✅ = runnable + unit-tested now (no GPU). 🏗 = real architecture; training wired
-when FOMO300K / cleared partner data + GPUs are available (see data-strategy, §6).
+✅ = runnable + unit-tested. Each stage has a working training loop
+(`<package>/train.py`) that runs on GPU and versions its checkpoint in the
+registry. The loops use **synthetic placeholder data** so they run today; real
+training swaps in FOMO300K / a commercially-cleared partner dataset (and, for
+report-gen, the gated Llama weights) — see data-strategy §6.2 / decision D10.
+Verified on 2× NVIDIA A10.
 
 ## Quick start (registry + eval, no GPU)
 
@@ -39,6 +43,32 @@ python -m ml_engine.cli sign-off --model mr-report-gen:0.1.0 --reviewer dr.x
 python -m ml_engine.cli promote  --model mr-report-gen:0.1.0   # -> production (locked)
 python -m ml_engine.cli list
 ```
+
+## Training the model stages (GPU)
+
+```bash
+pip install torch transformers peft monai     # GPU host
+CK=checkpoints
+
+# SCRUM-21 — encoder SSL pretraining (masked-volume), multi-GPU + AMP
+python -m ml_engine.encoder.train --amp --data-parallel --register \
+    --name mr-encoder --version 0.1.0-ssl --out $CK
+
+# SCRUM-22 — contrastive image–text alignment, warm-started from the SSL encoder
+python -m ml_engine.alignment.train --amp --register \
+    --encoder-ckpt $CK/mr-encoder-0.1.0-ssl.pt --out $CK
+
+# SCRUM-24 — triage head: supervised train + temperature calibration
+python -m ml_engine.triage_head.train --register --out $CK
+
+# SCRUM-23 — report generator LoRA fine-tune (override --llm to the gated Llama
+# once an HF token + accepted licence are in place)
+python -m ml_engine.report_gen.train --register --out $CK \
+    --llm hf-internal-testing/tiny-random-LlamaForCausalLM
+```
+
+Each `--register` versions the resulting checkpoint in the model registry, so it
+flows straight into the `eval → promote → sign-off` lifecycle above.
 
 ## Promotion gates (`config/settings.py`, override via `AMAN_ML_*`)
 

--- a/backend/ml_engine/alignment/train.py
+++ b/backend/ml_engine/alignment/train.py
@@ -1,0 +1,224 @@
+"""Contrastive image-text alignment training (SCRUM-22, §7.1 Stage B).
+
+Trains :class:`ml_engine.alignment.MRCLIP` with the symmetric InfoNCE objective
+on (volume, report-text-embedding) pairs, warm-starting the image encoder from
+the SCRUM-21 SSL checkpoint when available. Reports a zero-shot retrieval
+baseline (batch image->text top-1) and versions the checkpoint in the registry.
+
+Scaffold caveats: pairs are synthetic (deterministic per-sample volume + a
+paired pseudo text embedding) so the loop is runnable today; real training uses
+report-paired studies with a frozen clinical text encoder. See data-strategy
+§6.2 / decision D10.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from ..encoder.encoder import EncoderConfig, MRIEncoder3D
+from ..encoder.train import cosine_warmup
+from .mr_clip import MRCLIP, MRCLIPConfig
+
+
+class PairedVolumeText(Dataset):
+    """Volume/text pairs built from a shared per-sample latent ``z``.
+
+    Both the volume (a low-frequency field whose coarse content is a fixed
+    linear function of ``z``) and the paired text embedding (another fixed
+    linear function of ``z``) are generated from the *same* well-conditioned
+    latent. The image<->text correspondence is therefore genuinely learnable —
+    the encoder recovers ``z`` from the volume and aligns it with the text — so
+    the contrastive loss drops and batch retrieval rises well above chance.
+    Stands in for a real frozen clinical text encoder over paired reports.
+    """
+
+    POOL = 4
+
+    def __init__(self, cfg: EncoderConfig, text_dim: int, length: int = 512,
+                 latent_dim: int = 32, seed: int = 0):
+        self.cfg = cfg
+        self.text_dim = text_dim
+        self.latent_dim = latent_dim
+        self.length = length
+        self.seed = seed
+        coarse_dim = (self.POOL ** 3) * cfg.in_channels
+        g = torch.Generator().manual_seed(seed * 100003 + 7)
+        # fixed maps: latent -> coarse volume content, latent -> text embedding
+        self.to_coarse = torch.randn(coarse_dim, latent_dim, generator=g) / (latent_dim ** 0.5)
+        self.to_text = torch.randn(text_dim, latent_dim, generator=g) / (latent_dim ** 0.5)
+
+    def __len__(self) -> int:
+        return self.length
+
+    def __getitem__(self, idx: int):
+        g = torch.Generator().manual_seed(self.seed * 100003 + idx)
+        z = torch.randn(self.latent_dim, generator=g)
+        d, h, w = self.cfg.img_size
+        coarse = (self.to_coarse @ z).reshape(self.cfg.in_channels, self.POOL, self.POOL, self.POOL)
+        vol = torch.nn.functional.interpolate(
+            coarse.unsqueeze(0), size=(d, h, w), mode="trilinear", align_corners=False
+        ).squeeze(0)
+        vol = vol + 0.05 * torch.randn(self.cfg.in_channels, d, h, w, generator=g)
+        text = self.to_text @ z + 0.05 * torch.randn(self.text_dim, generator=g)
+        return vol, text
+
+
+@torch.no_grad()
+def zero_shot_top1(model: MRCLIP, vol: torch.Tensor, text: torch.Tensor) -> float:
+    """Batch image->text retrieval top-1 accuracy (diagonal = correct match)."""
+    img = torch.nn.functional.normalize(model.encode_image(vol), dim=-1)
+    txt = torch.nn.functional.normalize(model.encode_text(text), dim=-1)
+    sims = img @ txt.t()
+    pred = sims.argmax(dim=-1)
+    target = torch.arange(vol.size(0), device=vol.device)
+    return float((pred == target).float().mean())
+
+
+def run_alignment_training(
+    cfg: EncoderConfig,
+    clip_cfg: MRCLIPConfig | None = None,
+    *,
+    steps: int = 100,
+    batch_size: int = 16,
+    lr: float = 5e-4,
+    weight_decay: float = 0.1,
+    warmup: int = 10,
+    grad_clip: float = 1.0,
+    device: str = "cpu",
+    amp: bool = False,
+    dataset_len: int = 512,
+    log_every: int = 10,
+    out_dir: str | Path = "checkpoints",
+    name: str = "mr-clip",
+    version: str = "0.1.0",
+    encoder_ckpt: str | None = None,
+    register: bool = False,
+    code_commit: str = "",
+    seed: int = 0,
+) -> dict[str, Any]:
+    torch.manual_seed(seed)
+    dev = torch.device(device if (device != "cuda" or torch.cuda.is_available()) else "cpu")
+    clip_cfg = clip_cfg or MRCLIPConfig()
+
+    encoder = MRIEncoder3D(cfg)
+    warm = []
+    if encoder_ckpt:
+        warm = encoder.load_pretrained(encoder_ckpt)      # FOMO/SSL warm start
+    model = MRCLIP(encoder, clip_cfg).to(dev)
+
+    ds = PairedVolumeText(cfg, clip_cfg.text_dim, length=dataset_len, seed=seed)
+    loader = DataLoader(ds, batch_size=batch_size, shuffle=True, drop_last=True,
+                        num_workers=2 if dev.type == "cuda" else 0)
+
+    opt = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
+    sched = torch.optim.lr_scheduler.LambdaLR(
+        opt, lambda s: cosine_warmup(s, warmup=warmup, total=steps))
+    use_amp = amp and dev.type == "cuda"
+    scaler = torch.amp.GradScaler("cuda", enabled=use_amp)
+
+    model.train()
+    it = iter(loader)
+    first_loss = last_loss = float("nan")
+    last_top1 = float("nan")
+    for step in range(steps):
+        try:
+            vol, text = next(it)
+        except StopIteration:
+            it = iter(loader)
+            vol, text = next(it)
+        vol, text = vol.to(dev), text.to(dev)
+        opt.zero_grad(set_to_none=True)
+        with torch.autocast(device_type=dev.type, enabled=use_amp):
+            loss = model(vol, text)["loss"]
+        scaler.scale(loss).backward()
+        scaler.unscale_(opt)
+        torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
+        scaler.step(opt)
+        scaler.update()
+        # keep CLIP temperature in the stable CLIP range
+        with torch.no_grad():
+            model.logit_scale.clamp_(0, 4.6052)   # exp -> <=100
+        sched.step()
+        last_loss = float(loss.detach().cpu())
+        if step == 0:
+            first_loss = last_loss
+        if step % log_every == 0 or step == steps - 1:
+            model.eval()
+            last_top1 = zero_shot_top1(model, vol, text)
+            model.train()
+            print(json.dumps({"step": step, "loss": last_loss,
+                              "zeroshot_top1": last_top1,
+                              "lr": sched.get_last_lr()[0]}), flush=True)
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ckpt_path = out_dir / f"{name}-{version}.pt"
+    torch.save({"model": model.state_dict(), "cfg": asdict(cfg),
+                "clip_cfg": asdict(clip_cfg), "final_loss": last_loss,
+                "zeroshot_top1": last_top1, "objective": "info_nce"}, ckpt_path)
+
+    summary: dict[str, Any] = {
+        "name": name, "version": version, "device": str(dev), "amp": use_amp,
+        "steps": steps, "first_loss": first_loss, "final_loss": last_loss,
+        "zeroshot_top1": last_top1, "warm_start": bool(encoder_ckpt),
+        "warm_start_missing_keys": len(warm), "checkpoint": str(ckpt_path),
+    }
+    if register:
+        from ..registry import ModelRegistry
+        reg = ModelRegistry()
+        card = reg.register(
+            name=name, version=version, stage="alignment",
+            artifact_uri=str(ckpt_path.resolve()), code_commit=code_commit,
+            config={**asdict(clip_cfg), "objective": "info_nce",
+                    "zeroshot_top1": last_top1, "data": "synthetic-paired"},
+        )
+        summary["registered"] = card.model_id
+    print(json.dumps({"summary": summary}, default=str), flush=True)
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="ml_engine.alignment.train",
+                                 description="Contrastive image-text alignment (SCRUM-22)")
+    ap.add_argument("--steps", type=int, default=100)
+    ap.add_argument("--batch-size", type=int, default=16, dest="batch_size")
+    ap.add_argument("--img-size", type=int, default=128, dest="img_size")
+    ap.add_argument("--patch-size", type=int, default=16, dest="patch_size")
+    ap.add_argument("--embed-dim", type=int, default=768, dest="embed_dim")
+    ap.add_argument("--depth", type=int, default=12)
+    ap.add_argument("--heads", type=int, default=12)
+    ap.add_argument("--proj-dim", type=int, default=512, dest="proj_dim")
+    ap.add_argument("--text-dim", type=int, default=768, dest="text_dim")
+    ap.add_argument("--lr", type=float, default=5e-4)
+    ap.add_argument("--warmup", type=int, default=10)
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--amp", action="store_true")
+    ap.add_argument("--dataset-len", type=int, default=512, dest="dataset_len")
+    ap.add_argument("--out", default="checkpoints", dest="out_dir")
+    ap.add_argument("--name", default="mr-clip")
+    ap.add_argument("--version", default="0.1.0")
+    ap.add_argument("--encoder-ckpt", dest="encoder_ckpt", help="SSL warm-start checkpoint")
+    ap.add_argument("--register", action="store_true")
+    ap.add_argument("--commit", default="", dest="code_commit")
+    ap.add_argument("--seed", type=int, default=0)
+    a = ap.parse_args(argv)
+    cfg = EncoderConfig(img_size=(a.img_size,) * 3, patch_size=(a.patch_size,) * 3,
+                        embed_dim=a.embed_dim, depth=a.depth, num_heads=a.heads)
+    run_alignment_training(
+        cfg, MRCLIPConfig(proj_dim=a.proj_dim, text_dim=a.text_dim),
+        steps=a.steps, batch_size=a.batch_size, lr=a.lr, warmup=a.warmup,
+        device=a.device, amp=a.amp, dataset_len=a.dataset_len, out_dir=a.out_dir,
+        name=a.name, version=a.version, encoder_ckpt=a.encoder_ckpt,
+        register=a.register, code_commit=a.code_commit, seed=a.seed,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/ml_engine/encoder/data.py
+++ b/backend/ml_engine/encoder/data.py
@@ -1,0 +1,89 @@
+"""Real 3D MRI volume datasets (NIfTI) for training the model stages.
+
+Replaces the synthetic placeholder with genuine brain-MRI volumes. The loader
+reads NIfTI (``.nii`` / ``.nii.gz``), resamples to the encoder's ``img_size``,
+and applies per-volume intensity standardisation (z-score) — the same contract
+``SyntheticMRIVolumes`` exposes, so any train loop swaps data with one flag.
+
+``fetch_ixi_tiny`` pulls TorchIO's **IXITiny** — a small, openly licensed subset
+of the IXI brain-MRI dataset (CC BY-SA 3.0) — so training runs on real volumes
+today. For the *production* model, point ``--data-dir`` at the
+commercially-cleared partner dataset (decision D10); nothing else changes.
+"""
+from __future__ import annotations
+
+import glob
+import os
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from torch.utils.data import Dataset
+
+
+def load_nifti(path: str | Path, img_size=(128, 128, 128), in_channels: int = 1) -> torch.Tensor:
+    """Load one NIfTI file -> standardised ``(C, D, H, W)`` tensor."""
+    import nibabel as nib  # lazy
+    arr = nib.load(str(path)).get_fdata(dtype="float32")
+    vol = torch.from_numpy(arr)
+    while vol.ndim < 3:
+        vol = vol.unsqueeze(-1)
+    vol = vol[..., 0] if vol.ndim == 4 else vol
+    vol = vol.reshape(vol.shape[0], vol.shape[1], vol.shape[2])
+    vol = F.interpolate(vol[None, None], size=tuple(img_size), mode="trilinear",
+                        align_corners=False)[0]
+    if in_channels > 1:
+        vol = vol.expand(in_channels, *tuple(img_size)).contiguous()
+    return (vol - vol.mean()) / (vol.std() + 1e-6)
+
+
+class NiftiVolumeDataset(Dataset):
+    """Folder of NIfTI volumes -> standardised ``(C, D, H, W)`` tensors."""
+
+    def __init__(self, root: str | Path, img_size=(128, 128, 128),
+                 in_channels: int = 1, pattern: str = "**/*.nii*",
+                 cache: bool = True):
+        self.paths = sorted(glob.glob(os.path.join(str(root), pattern), recursive=True))
+        if not self.paths:
+            raise FileNotFoundError(f"no NIfTI volumes under {root} (pattern {pattern})")
+        self.img_size = tuple(img_size)
+        self.in_channels = in_channels
+        self._cache: dict[int, torch.Tensor] = {} if cache else None
+
+    def __len__(self) -> int:
+        return len(self.paths)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        if self._cache is not None and idx in self._cache:
+            return self._cache[idx]
+        import nibabel as nib  # lazy: keep nibabel optional
+        arr = nib.load(self.paths[idx]).get_fdata(dtype="float32")
+        vol = torch.from_numpy(arr)
+        while vol.ndim < 3:
+            vol = vol.unsqueeze(-1)
+        vol = vol[..., :1] if vol.ndim == 4 else vol      # drop extra modalities
+        vol = vol.reshape(vol.shape[0], vol.shape[1], vol.shape[2])
+        vol = F.interpolate(vol[None, None], size=self.img_size, mode="trilinear",
+                            align_corners=False)[0]        # (1, D, H, W)
+        if self.in_channels > 1:
+            vol = vol.expand(self.in_channels, *self.img_size).contiguous()
+        vol = (vol - vol.mean()) / (vol.std() + 1e-6)
+        if self._cache is not None:
+            self._cache[idx] = vol
+        return vol
+
+
+def fetch_ixi_tiny(dest: str | Path) -> str:
+    """Download TorchIO's IXITiny (real open brain-MRI T1 subset).
+
+    Returns the directory of ``.nii.gz`` image volumes, suitable for
+    :class:`NiftiVolumeDataset`.
+    """
+    import torchio as tio  # lazy
+    dest = Path(dest)
+    tio.datasets.IXITiny(str(dest), download=True)
+    image_dir = dest / "image"
+    if not image_dir.exists():
+        # some torchio versions nest differently; fall back to a recursive search
+        image_dir = dest
+    return str(image_dir)

--- a/backend/ml_engine/encoder/train.py
+++ b/backend/ml_engine/encoder/train.py
@@ -1,0 +1,272 @@
+"""SSL pretraining loop for the 3D MRI encoder (SCRUM-21, §7.1 Stage A).
+
+Drives :class:`ml_engine.encoder.MaskedVolumeSSL` through a masked-volume
+reconstruction objective and versions the resulting checkpoint in the model
+registry (SCRUM-27) — satisfying the SCRUM-21 acceptance criteria:
+
+  * masked-volume SSL objective with an optimiser/schedule/AMP loop;
+  * checkpoints versioned in the registry;
+  * FOMO300K weights can warm-start via ``MRIEncoder3D.load_pretrained``.
+
+Runs on CPU (tiny config, used by the smoke test) or on one/both A10 GPUs.
+
+Scaffold caveats (deliberately explicit — do not mistake this for the final
+training run):
+  * **Data is synthetic.** Real pretraining needs FOMO300K / a commercially
+    cleared partner dataset (blocked — see vault data-strategy §6.2 / decision
+    D10). Swap :class:`SyntheticMRIVolumes` for the real loader; nothing else
+    in the loop changes.
+  * The current ``MaskedVolumeSSL`` encodes the *full* volume and applies the
+    reconstruction loss only on the masked patch subset (masked-target MAE),
+    rather than dropping masked tokens from the encoder input. Good enough to
+    exercise the pipeline; tighten to true input-masking before real runs.
+  * Linear-probe-beats-from-scratch (the 3rd acceptance criterion) is a
+    downstream eval, not part of this loop — tracked as a follow-up.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from .encoder import EncoderConfig, MRIEncoder3D, MaskedVolumeSSL
+
+
+# --------------------------------------------------------------------------- #
+# Data
+# --------------------------------------------------------------------------- #
+class SyntheticMRIVolumes(Dataset):
+    """Placeholder dataset of structured-noise volumes.
+
+    Stands in for FOMO300K / cleared partner data so the training pipeline is
+    runnable today. Each sample is a single-sequence volume ``(C, D, H, W)``
+    with smooth low-frequency structure (so reconstruction is non-trivial),
+    seeded deterministically for reproducibility.
+    """
+
+    def __init__(self, cfg: EncoderConfig, length: int = 256, seed: int = 0):
+        self.cfg = cfg
+        self.length = length
+        self.seed = seed
+
+    def __len__(self) -> int:
+        return self.length
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        g = torch.Generator().manual_seed(self.seed + idx)
+        d, h, w = self.cfg.img_size
+        # low-res random field upsampled -> smooth spatial structure
+        coarse = torch.rand(self.cfg.in_channels, d // 4 or 1, h // 4 or 1,
+                            w // 4 or 1, generator=g)
+        vol = torch.nn.functional.interpolate(
+            coarse.unsqueeze(0), size=(d, h, w), mode="trilinear",
+            align_corners=False,
+        ).squeeze(0)
+        # per-volume z-score (mimics intensity standardisation)
+        return (vol - vol.mean()) / (vol.std() + 1e-6)
+
+
+def patchify(vol: torch.Tensor, patch_size: tuple[int, int, int]) -> torch.Tensor:
+    """``(B, C, D, H, W)`` -> ``(B, N, C*pz*py*px)`` in encoder token order.
+
+    Patch ordering over the (D, H, W) grid is row-major, matching the flatten
+    order of :class:`PatchEmbed3D`'s ``Conv3d`` output, so reconstruction
+    targets line up with the encoder's patch tokens.
+    """
+    b, c, d, h, w = vol.shape
+    pz, py, px = patch_size
+    dg, hg, wg = d // pz, h // py, w // px
+    x = vol.reshape(b, c, dg, pz, hg, py, wg, px)
+    x = x.permute(0, 2, 4, 6, 1, 3, 5, 7).contiguous()
+    return x.reshape(b, dg * hg * wg, c * pz * py * px)
+
+
+# --------------------------------------------------------------------------- #
+# Schedule
+# --------------------------------------------------------------------------- #
+def cosine_warmup(step: int, *, warmup: int, total: int) -> float:
+    """LR multiplier: linear warmup then cosine decay to ~0."""
+    if step < warmup:
+        return (step + 1) / max(1, warmup)
+    progress = (step - warmup) / max(1, total - warmup)
+    return 0.5 * (1.0 + math.cos(math.pi * min(1.0, progress)))
+
+
+# --------------------------------------------------------------------------- #
+# Training
+# --------------------------------------------------------------------------- #
+def run_training(
+    cfg: EncoderConfig,
+    *,
+    steps: int = 100,
+    batch_size: int = 4,
+    lr: float = 1.5e-4,
+    weight_decay: float = 0.05,
+    warmup: int = 10,
+    grad_clip: float = 1.0,
+    device: str = "cpu",
+    amp: bool = False,
+    data_parallel: bool = False,
+    dataset_len: int = 1024,
+    log_every: int = 10,
+    out_dir: str | Path = "checkpoints",
+    version: str = "0.1.0",
+    name: str = "mr-encoder",
+    register: bool = False,
+    code_commit: str = "",
+    seed: int = 0,
+) -> dict[str, Any]:
+    torch.manual_seed(seed)
+    dev = torch.device(device if (device != "cuda" or torch.cuda.is_available()) else "cpu")
+
+    encoder = MRIEncoder3D(cfg)
+    model = MaskedVolumeSSL(encoder).to(dev)
+
+    multi_gpu = data_parallel and dev.type == "cuda" and torch.cuda.device_count() > 1
+    train_model = torch.nn.DataParallel(model) if multi_gpu else model
+
+    ds = SyntheticMRIVolumes(cfg, length=dataset_len, seed=seed)
+    loader = DataLoader(ds, batch_size=batch_size, shuffle=True, drop_last=True,
+                        num_workers=2 if dev.type == "cuda" else 0)
+
+    opt = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay,
+                            betas=(0.9, 0.95))
+    sched = torch.optim.lr_scheduler.LambdaLR(
+        opt, lambda s: cosine_warmup(s, warmup=warmup, total=steps))
+    use_amp = amp and dev.type == "cuda"
+    scaler = torch.amp.GradScaler("cuda", enabled=use_amp)
+
+    train_model.train()
+    history: list[dict[str, float]] = []
+    step = 0
+    data_iter = iter(loader)
+    first_loss = last_loss = float("nan")
+    while step < steps:
+        try:
+            vol = next(data_iter)
+        except StopIteration:
+            data_iter = iter(loader)
+            vol = next(data_iter)
+        vol = vol.to(dev, non_blocking=True)
+        target = patchify(vol, cfg.patch_size).to(dev, non_blocking=True)
+
+        opt.zero_grad(set_to_none=True)
+        with torch.autocast(device_type=dev.type, enabled=use_amp):
+            loss = train_model(vol, target)
+            if multi_gpu:                 # DataParallel gathers one scalar per replica
+                loss = loss.mean()
+        scaler.scale(loss).backward()
+        scaler.unscale_(opt)
+        torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
+        scaler.step(opt)
+        scaler.update()
+        sched.step()
+
+        last_loss = float(loss.detach().cpu())
+        if step == 0:
+            first_loss = last_loss
+        if step % log_every == 0 or step == steps - 1:
+            rec = {"step": step, "loss": last_loss, "lr": sched.get_last_lr()[0]}
+            history.append(rec)
+            print(json.dumps(rec), flush=True)
+        step += 1
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ckpt_path = out_dir / f"{name}-{version}.pt"
+    torch.save({
+        "model": encoder.state_dict(),       # encoder-only -> load_pretrained compatible
+        "cfg": asdict(cfg),
+        "step": step,
+        "final_loss": last_loss,
+        "objective": "masked_volume_ssl",
+    }, ckpt_path)
+
+    summary: dict[str, Any] = {
+        "name": name,
+        "version": version,
+        "device": str(dev),
+        "multi_gpu": multi_gpu,
+        "amp": use_amp,
+        "steps": step,
+        "first_loss": first_loss,
+        "final_loss": last_loss,
+        "checkpoint": str(ckpt_path),
+        "params_M": round(sum(p.numel() for p in encoder.parameters()) / 1e6, 2),
+    }
+
+    if register:
+        # Lazy import: keeps torch-only training decoupled from the registry.
+        from ..registry import ModelRegistry
+        reg = ModelRegistry()
+        card = reg.register(
+            name=name, version=version, stage="encoder",
+            artifact_uri=str(ckpt_path.resolve()), code_commit=code_commit,
+            config={**asdict(cfg), "objective": "masked_volume_ssl",
+                    "steps": step, "final_loss": last_loss,
+                    "data": "synthetic-placeholder"},
+        )
+        summary["registered"] = card.model_id
+
+    print(json.dumps({"summary": summary}, default=str), flush=True)
+    return summary
+
+
+def _build_cfg(args: argparse.Namespace) -> EncoderConfig:
+    s = args.img_size
+    p = args.patch_size
+    return EncoderConfig(
+        in_channels=1,
+        img_size=(s, s, s), patch_size=(p, p, p),
+        embed_dim=args.embed_dim, depth=args.depth, num_heads=args.heads,
+        mask_ratio=args.mask_ratio,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="ml_engine.encoder.train",
+                                 description="SSL pretrain the 3D MRI encoder (SCRUM-21)")
+    ap.add_argument("--steps", type=int, default=100)
+    ap.add_argument("--batch-size", type=int, default=4, dest="batch_size")
+    ap.add_argument("--img-size", type=int, default=128, dest="img_size")
+    ap.add_argument("--patch-size", type=int, default=16, dest="patch_size")
+    ap.add_argument("--embed-dim", type=int, default=768, dest="embed_dim")
+    ap.add_argument("--depth", type=int, default=12)
+    ap.add_argument("--heads", type=int, default=12)
+    ap.add_argument("--mask-ratio", type=float, default=0.75, dest="mask_ratio")
+    ap.add_argument("--lr", type=float, default=1.5e-4)
+    ap.add_argument("--warmup", type=int, default=10)
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--amp", action="store_true", help="mixed precision (GPU)")
+    ap.add_argument("--data-parallel", action="store_true", dest="data_parallel",
+                    help="use all visible GPUs via DataParallel")
+    ap.add_argument("--dataset-len", type=int, default=1024, dest="dataset_len")
+    ap.add_argument("--out", default="checkpoints", dest="out_dir")
+    ap.add_argument("--name", default="mr-encoder")
+    ap.add_argument("--version", default="0.1.0")
+    ap.add_argument("--register", action="store_true",
+                    help="version the checkpoint in the model registry")
+    ap.add_argument("--commit", default="", dest="code_commit")
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args(argv)
+
+    run_training(
+        _build_cfg(args),
+        steps=args.steps, batch_size=args.batch_size, lr=args.lr,
+        warmup=args.warmup, device=args.device, amp=args.amp,
+        data_parallel=args.data_parallel, dataset_len=args.dataset_len,
+        out_dir=args.out_dir, version=args.version, name=args.name,
+        register=args.register, code_commit=args.code_commit, seed=args.seed,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/ml_engine/encoder/train.py
+++ b/backend/ml_engine/encoder/train.py
@@ -121,6 +121,7 @@ def run_training(
     name: str = "mr-encoder",
     register: bool = False,
     code_commit: str = "",
+    data_dir: str | None = None,
     seed: int = 0,
 ) -> dict[str, Any]:
     torch.manual_seed(seed)
@@ -132,7 +133,13 @@ def run_training(
     multi_gpu = data_parallel and dev.type == "cuda" and torch.cuda.device_count() > 1
     train_model = torch.nn.DataParallel(model) if multi_gpu else model
 
-    ds = SyntheticMRIVolumes(cfg, length=dataset_len, seed=seed)
+    if data_dir:
+        from .data import NiftiVolumeDataset
+        ds = NiftiVolumeDataset(data_dir, img_size=cfg.img_size, in_channels=cfg.in_channels)
+        data_source = f"nifti:{data_dir} ({len(ds)} volumes)"
+    else:
+        ds = SyntheticMRIVolumes(cfg, length=dataset_len, seed=seed)
+        data_source = "synthetic-placeholder"
     loader = DataLoader(ds, batch_size=batch_size, shuffle=True, drop_last=True,
                         num_workers=2 if dev.type == "cuda" else 0)
 
@@ -200,6 +207,7 @@ def run_training(
         "final_loss": last_loss,
         "checkpoint": str(ckpt_path),
         "params_M": round(sum(p.numel() for p in encoder.parameters()) / 1e6, 2),
+        "data": data_source,
     }
 
     if register:
@@ -211,7 +219,7 @@ def run_training(
             artifact_uri=str(ckpt_path.resolve()), code_commit=code_commit,
             config={**asdict(cfg), "objective": "masked_volume_ssl",
                     "steps": step, "final_loss": last_loss,
-                    "data": "synthetic-placeholder"},
+                    "data": data_source},
         )
         summary["registered"] = card.model_id
 
@@ -254,6 +262,8 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--register", action="store_true",
                     help="version the checkpoint in the model registry")
     ap.add_argument("--commit", default="", dest="code_commit")
+    ap.add_argument("--data-dir", default=None, dest="data_dir",
+                    help="folder of NIfTI volumes (real data); omit for synthetic")
     ap.add_argument("--seed", type=int, default=0)
     args = ap.parse_args(argv)
 
@@ -263,7 +273,8 @@ def main(argv: list[str] | None = None) -> int:
         warmup=args.warmup, device=args.device, amp=args.amp,
         data_parallel=args.data_parallel, dataset_len=args.dataset_len,
         out_dir=args.out_dir, version=args.version, name=args.name,
-        register=args.register, code_commit=args.code_commit, seed=args.seed,
+        register=args.register, code_commit=args.code_commit,
+        data_dir=args.data_dir, seed=args.seed,
     )
     return 0
 

--- a/backend/ml_engine/ingestion/__init__.py
+++ b/backend/ml_engine/ingestion/__init__.py
@@ -1,0 +1,9 @@
+"""Compliant data ingestion (DICOM de-identification + standardisation)."""
+from .dicom import (
+    IngestionManifest, deidentify, has_phi, load_series, pseudonymise, series_to_volume,
+)
+
+__all__ = [
+    "IngestionManifest", "deidentify", "has_phi", "load_series",
+    "pseudonymise", "series_to_volume",
+]

--- a/backend/ml_engine/ingestion/dicom.py
+++ b/backend/ml_engine/ingestion/dicom.py
@@ -1,0 +1,125 @@
+"""DICOM ingestion + de-identification (data pipeline, §3.3 / §6.4).
+
+Hospital MRI arrives as DICOM series carrying PHI. Before any study reaches the
+models it must be (1) **de-identified** — identifying tags removed and the
+patient id replaced by a salted pseudonym — and (2) **standardised** into a
+model-ready volume. This module does both and emits a provenance manifest that
+maps onto the registry's :class:`DataProvenance` (so a trained model records
+exactly which data — and whether it was licence-cleared — it saw).
+
+This is the bridge to the commercially-cleared partner dataset (decision D10):
+the loaders/train loops already take a NIfTI dir; this adds the compliant
+DICOM→volume front door for real hospital data. Set ``license_cleared=True``
+only for data with a signed clearance.
+"""
+from __future__ import annotations
+
+import glob
+import hashlib
+import os
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+# Tags that carry protected health information — blanked on ingest.
+PHI_TAGS = (
+    "PatientName", "PatientID", "PatientBirthDate", "PatientAddress",
+    "PatientTelephoneNumbers", "OtherPatientIDs", "OtherPatientNames",
+    "ReferringPhysicianName", "PerformingPhysicianName", "OperatorsName",
+    "InstitutionName", "InstitutionAddress", "StationName",
+    "AccessionNumber", "StudyID", "DeviceSerialNumber",
+)
+
+
+@dataclass
+class IngestionManifest:
+    """Provenance for one ingested study (feeds registry DataProvenance)."""
+
+    pseudo_id: str                       # salted hash of the original PatientID
+    sequence: str = ""                   # T1 / T2 / FLAIR / SWI (best-effort)
+    modality: str = ""
+    n_slices: int = 0
+    spacing: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    deidentified: bool = True
+    license_cleared: bool = False        # set True ONLY for signed-clearance data
+    source: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def pseudonymise(patient_id: str, salt: str = "aman") -> str:
+    return hashlib.sha256(f"{salt}:{patient_id}".encode()).hexdigest()[:16]
+
+
+def deidentify(ds, salt: str = "aman") -> str:
+    """Blank PHI tags in-place; return the pseudonymous id. ``ds`` is a pydicom Dataset."""
+    original = str(getattr(ds, "PatientID", "") or "")
+    pseudo = pseudonymise(original, salt)
+    for tag in PHI_TAGS:
+        if tag in ds:
+            ds.data_element(tag).value = ""
+    ds.PatientID = pseudo
+    ds.PatientIdentityRemoved = "YES"
+    ds.DeidentificationMethod = "aman-ml PHI tag removal + pseudonymisation"
+    return pseudo
+
+
+def has_phi(ds) -> bool:
+    """True if any PHI tag still carries a value (post-deid verification)."""
+    return any(tag in ds and str(ds.data_element(tag).value) not in ("", "None")
+               for tag in PHI_TAGS if tag != "PatientID")
+
+
+def load_series(dicom_dir: str | Path, *, salt: str = "aman", deid: bool = True):
+    """Load + (optionally) de-identify a DICOM series -> (volume D,H,W, manifest)."""
+    import pydicom  # lazy
+    paths = sorted(glob.glob(os.path.join(str(dicom_dir), "**", "*.dcm"), recursive=True)) \
+        or sorted(glob.glob(os.path.join(str(dicom_dir), "*")))
+    slices = []
+    for p in paths:
+        try:
+            slices.append(pydicom.dcmread(p))
+        except Exception:
+            continue
+    if not slices:
+        raise FileNotFoundError(f"no readable DICOM under {dicom_dir}")
+    # order by spatial position when available, else InstanceNumber
+    def _key(s):
+        ipp = getattr(s, "ImagePositionPatient", None)
+        return float(ipp[2]) if ipp else float(getattr(s, "InstanceNumber", 0) or 0)
+    slices.sort(key=_key)
+
+    pseudo = ""
+    for s in slices:
+        pid = deidentify(s, salt) if deid else pseudonymise(str(getattr(s, "PatientID", "")), salt)
+        pseudo = pid
+
+    vol = torch.stack([torch.as_tensor(s.pixel_array, dtype=torch.float32) for s in slices])
+    px = getattr(slices[0], "PixelSpacing", [1.0, 1.0])
+    thick = float(getattr(slices[0], "SliceThickness", 1.0) or 1.0)
+    manifest = IngestionManifest(
+        pseudo_id=pseudo,
+        sequence=str(getattr(slices[0], "SeriesDescription", "") or ""),
+        modality=str(getattr(slices[0], "Modality", "") or ""),
+        n_slices=len(slices),
+        spacing=(thick, float(px[0]), float(px[1])),
+        deidentified=deid,
+        source=str(dicom_dir),
+    )
+    return vol, manifest
+
+
+def series_to_volume(dicom_dir: str | Path, img_size=(128, 128, 128),
+                     in_channels: int = 1, *, deid: bool = True):
+    """DICOM series -> standardised ``(C, D, H, W)`` tensor + manifest."""
+    vol, manifest = load_series(dicom_dir, deid=deid)
+    vol = F.interpolate(vol[None, None], size=tuple(img_size), mode="trilinear",
+                        align_corners=False)[0]
+    if in_channels > 1:
+        vol = vol.expand(in_channels, *tuple(img_size)).contiguous()
+    vol = (vol - vol.mean()) / (vol.std() + 1e-6)
+    return vol, manifest

--- a/backend/ml_engine/report_gen/generator.py
+++ b/backend/ml_engine/report_gen/generator.py
@@ -35,7 +35,10 @@ class StructuredFinding:
 
 @dataclass
 class ReportGenConfig:
-    llm_name: str = "meta-llama/Llama-3.2-3B-Instruct"  # swap per licensing/budget
+    # Default to an ungated, commercially-usable open model (Apache-2.0) so the
+    # report generator trains/serves with no licence gate. Swap to a gated model
+    # (e.g. meta-llama/Llama-3.2-3B-Instruct) once a token + licence are in place.
+    llm_name: str = "Qwen/Qwen2.5-1.5B-Instruct"
     n_visual_tokens: int = 32
     lora_r: int = 16
     lora_alpha: int = 32
@@ -134,10 +137,22 @@ class ReportGenerator(nn.Module):
         return self.llm(inputs_embeds=inputs_embeds, attention_mask=attn,
                         labels=full_labels).loss
 
-    def generate(self, volume: torch.Tensor, prompt: str) -> dict:  # pragma: no cover
+    @torch.no_grad()
+    def generate(self, volume: torch.Tensor, prompt: str = "Findings:") -> dict:
+        """Generate a report: prepend the visual prefix and decode with the LLM."""
         if self.llm is None:
             raise RuntimeError("call attach_llm() before generate()")
-        # Implementation note: prepend visual_prefix() to the embedded prompt,
-        # run constrained decoding against findings_vocab, then parse Findings /
-        # Impression + StructuredFinding[]. Left for the training milestone.
-        raise NotImplementedError("generation wired at the training milestone (needs LLM weights)")
+        dev = next(self.llm.parameters()).device
+        vis = self.visual_prefix(volume.to(dev))
+        enc = self.tokenizer([prompt] * vis.shape[0], return_tensors="pt", padding=True).to(dev)
+        tok_embeds = self.llm.get_input_embeddings()(enc["input_ids"]).to(vis.dtype)
+        inputs_embeds = torch.cat([vis, tok_embeds], dim=1)
+        vis_mask = torch.ones(vis.shape[0], vis.shape[1], dtype=enc["attention_mask"].dtype, device=dev)
+        attn = torch.cat([vis_mask, enc["attention_mask"]], dim=1)
+        out = self.llm.generate(
+            inputs_embeds=inputs_embeds, attention_mask=attn,
+            max_new_tokens=self.cfg.max_new_tokens, do_sample=False,
+            pad_token_id=self.tokenizer.pad_token_id or self.tokenizer.eos_token_id,
+        )
+        text = self.tokenizer.batch_decode(out, skip_special_tokens=True)
+        return {"text": text, "n_visual_tokens": vis.shape[1]}

--- a/backend/ml_engine/report_gen/generator.py
+++ b/backend/ml_engine/report_gen/generator.py
@@ -92,13 +92,47 @@ class ReportGenerator(nn.Module):
             task_type="CAUSAL_LM",
         )
         self.llm = get_peft_model(base, lora)
-        self.llm_dim = self.llm.config.hidden_size
+        hidden = self.llm.config.hidden_size
+        if hidden != self.llm_dim:
+            # The projector must emit tokens in the *actual* LLM embedding space;
+            # rebuild it once the real hidden size is known (constructor used a
+            # placeholder llm_dim before the weights were loaded).
+            self.llm_dim = hidden
+            self.projector = VisualProjector(
+                self.encoder.embed_dim, self.llm_dim, self.cfg.n_visual_tokens
+            ).to(next(self.projector.parameters()).device)
         return self
 
     def visual_prefix(self, volume: torch.Tensor) -> torch.Tensor:
         """Visual tokens to prepend to the LLM prompt embeddings."""
         patch_tokens = self.encoder(volume)["patch_tokens"]
         return self.projector(patch_tokens)
+
+    def training_step(
+        self,
+        volume: torch.Tensor,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        labels: torch.Tensor,
+    ) -> torch.Tensor:
+        """Causal-LM loss on (volume -> report) pairs.
+
+        Prepends the visual prefix to the embedded prompt and masks the visual
+        positions out of the loss (label ``-100``). Works with any attached
+        ``transformers`` causal LM (LoRA-adapted). Used by ``report_gen.train``.
+        """
+        if self.llm is None:
+            raise RuntimeError("call attach_llm() before training_step()")
+        tok_embeds = self.llm.get_input_embeddings()(input_ids)      # (B, T, D)
+        vis = self.visual_prefix(volume).to(tok_embeds.dtype)        # (B, n_vis, D)
+        b, n_vis = vis.shape[0], vis.shape[1]
+        inputs_embeds = torch.cat([vis, tok_embeds], dim=1)
+        vis_mask = torch.ones(b, n_vis, dtype=attention_mask.dtype, device=attention_mask.device)
+        attn = torch.cat([vis_mask, attention_mask], dim=1)
+        vis_labels = torch.full((b, n_vis), -100, dtype=labels.dtype, device=labels.device)
+        full_labels = torch.cat([vis_labels, labels], dim=1)
+        return self.llm(inputs_embeds=inputs_embeds, attention_mask=attn,
+                        labels=full_labels).loss
 
     def generate(self, volume: torch.Tensor, prompt: str) -> dict:  # pragma: no cover
         if self.llm is None:

--- a/backend/ml_engine/report_gen/train.py
+++ b/backend/ml_engine/report_gen/train.py
@@ -1,0 +1,160 @@
+"""LoRA fine-tuning loop for the report generator (SCRUM-23, §7.1 Stage C).
+
+Drives :class:`ml_engine.report_gen.ReportGenerator` on (volume -> report)
+pairs: the visual prefix + the LoRA-adapted causal LM are trained with the
+causal-LM loss; the base LLM and the image encoder are frozen. Versions the
+trained adapter + projector in the registry.
+
+Model licensing: the production target is ``meta-llama/Llama-3.2-3B-Instruct``,
+which is **gated** (needs an HF token + accepted licence) — the same
+licensing-gate theme as the training data (decision D10). This loop is verified
+end-to-end with a small open model (override ``--llm``); swap ``--llm`` to the
+Llama checkpoint once the token/licence is in place. Pairs are synthetic
+placeholders; real fine-tuning uses report-paired studies.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from ..encoder.encoder import EncoderConfig, MRIEncoder3D
+from ..encoder.train import SyntheticMRIVolumes
+from .generator import ReportGenerator, ReportGenConfig
+
+
+_REPORT_TEMPLATES = [
+    "Findings: no acute intracranial abnormality. Impression: normal study.",
+    "Findings: small acute infarct in the left frontal lobe. Impression: acute ischaemia.",
+    "Findings: intracranial haemorrhage with surrounding oedema. Impression: urgent review.",
+    "Findings: mass effect with midline shift. Impression: space-occupying lesion.",
+]
+
+
+def run_report_training(
+    cfg: EncoderConfig,
+    rg_cfg: ReportGenConfig | None = None,
+    *,
+    llm_name: str | None = None,
+    steps: int = 30,
+    batch_size: int = 2,
+    lr: float = 1e-4,
+    device: str = "cpu",
+    max_len: int = 48,
+    log_every: int = 5,
+    out_dir: str | Path = "checkpoints",
+    name: str = "mr-report-gen",
+    version: str = "0.1.0",
+    register: bool = False,
+    code_commit: str = "",
+    seed: int = 0,
+) -> dict[str, Any]:
+    torch.manual_seed(seed)
+    dev = torch.device(device if (device != "cuda" or torch.cuda.is_available()) else "cpu")
+    rg_cfg = rg_cfg or ReportGenConfig()
+    if llm_name:
+        rg_cfg.llm_name = llm_name
+
+    encoder = MRIEncoder3D(cfg)
+    model = ReportGenerator(encoder, rg_cfg).attach_llm().to(dev)
+    encoder.requires_grad_(False)        # freeze image encoder; train projector + LoRA
+
+    tok = model.tokenizer
+    if tok.pad_token is None:
+        tok.pad_token = tok.eos_token
+
+    vols = SyntheticMRIVolumes(cfg, length=max(batch_size * 8, 16), seed=seed)
+
+    def make_batch(step: int):
+        idx = [(step * batch_size + i) % len(vols) for i in range(batch_size)]
+        vol = torch.stack([vols[i] for i in idx]).to(dev)
+        texts = [_REPORT_TEMPLATES[i % len(_REPORT_TEMPLATES)] for i in idx]
+        enc = tok(texts, return_tensors="pt", padding="max_length",
+                  truncation=True, max_length=max_len)
+        input_ids = enc["input_ids"].to(dev)
+        attn = enc["attention_mask"].to(dev)
+        labels = input_ids.clone()
+        labels[attn == 0] = -100
+        return vol, input_ids, attn, labels
+
+    trainable = [p for p in model.parameters() if p.requires_grad]
+    opt = torch.optim.AdamW(trainable, lr=lr)
+
+    model.train()
+    first_loss = last_loss = float("nan")
+    for step in range(steps):
+        vol, input_ids, attn, labels = make_batch(step)
+        loss = model.training_step(vol, input_ids, attn, labels)
+        opt.zero_grad(set_to_none=True)
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(trainable, 1.0)
+        opt.step()
+        last_loss = float(loss.detach().cpu())
+        if step == 0:
+            first_loss = last_loss
+        if step % log_every == 0 or step == steps - 1:
+            print(json.dumps({"step": step, "lm_loss": last_loss}), flush=True)
+
+    out_dir = Path(out_dir)
+    ckpt_dir = Path(out_dir) / f"{name}-{version}"
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+    torch.save(model.projector.state_dict(), ckpt_dir / "projector.pt")
+    model.llm.save_pretrained(ckpt_dir / "lora_adapter")     # peft adapter only
+    n_trainable = sum(p.numel() for p in trainable)
+
+    summary: dict[str, Any] = {
+        "name": name, "version": version, "device": str(dev),
+        "llm": rg_cfg.llm_name, "steps": steps, "first_loss": first_loss,
+        "final_loss": last_loss, "trainable_params": n_trainable,
+        "checkpoint": str(ckpt_dir),
+    }
+    if register:
+        from ..registry import ModelRegistry
+        reg = ModelRegistry()
+        card = reg.register(
+            name=name, version=version, stage="report_gen",
+            artifact_uri=str(ckpt_dir.resolve()), code_commit=code_commit,
+            config={"llm": rg_cfg.llm_name, "lora_r": rg_cfg.lora_r,
+                    "n_visual_tokens": rg_cfg.n_visual_tokens,
+                    "final_loss": last_loss, "data": "synthetic"},
+        )
+        summary["registered"] = card.model_id
+    print(json.dumps({"summary": summary}, default=str), flush=True)
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="ml_engine.report_gen.train",
+                                 description="LoRA fine-tune the report generator (SCRUM-23)")
+    ap.add_argument("--llm", default=None, help="HF model id (default: config Llama-3.2-3B; gated)")
+    ap.add_argument("--steps", type=int, default=30)
+    ap.add_argument("--batch-size", type=int, default=2, dest="batch_size")
+    ap.add_argument("--img-size", type=int, default=64, dest="img_size")
+    ap.add_argument("--patch-size", type=int, default=16, dest="patch_size")
+    ap.add_argument("--embed-dim", type=int, default=384, dest="embed_dim")
+    ap.add_argument("--depth", type=int, default=6)
+    ap.add_argument("--heads", type=int, default=6)
+    ap.add_argument("--lr", type=float, default=1e-4)
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--out", default="checkpoints", dest="out_dir")
+    ap.add_argument("--name", default="mr-report-gen")
+    ap.add_argument("--version", default="0.1.0")
+    ap.add_argument("--register", action="store_true")
+    ap.add_argument("--commit", default="", dest="code_commit")
+    ap.add_argument("--seed", type=int, default=0)
+    a = ap.parse_args(argv)
+    cfg = EncoderConfig(img_size=(a.img_size,) * 3, patch_size=(a.patch_size,) * 3,
+                        embed_dim=a.embed_dim, depth=a.depth, num_heads=a.heads)
+    run_report_training(
+        cfg, llm_name=a.llm, steps=a.steps, batch_size=a.batch_size, lr=a.lr,
+        device=a.device, out_dir=a.out_dir, name=a.name, version=a.version,
+        register=a.register, code_commit=a.code_commit, seed=a.seed,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/ml_engine/serving/Dockerfile
+++ b/backend/ml_engine/serving/Dockerfile
@@ -1,0 +1,27 @@
+# MRI AI engine — inference service (§7.5). Deploys alongside the platform
+# backend; mount its endpoints or run standalone. CPU image by default; for GPU
+# inference use an nvidia/cuda base and install the cuda torch wheel.
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# System libs for nibabel/medical IO.
+RUN apt-get update && apt-get install -y --no-install-recommends libgl1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Inference deps (CPU torch keeps the image small; swap for cu121 on GPU hosts).
+RUN pip install --no-cache-dir \
+    torch --index-url https://download.pytorch.org/whl/cpu \
+ && pip install --no-cache-dir \
+    numpy scikit-learn fastapi uvicorn python-multipart nibabel pydicom \
+    transformers peft
+
+COPY ml_engine /app/ml_engine
+
+# Provide trained checkpoints at runtime via env + a mounted volume:
+#   docker run -e AMAN_ML_ENCODER_CKPT=/ckpts/mr-encoder.pt \
+#              -e AMAN_ML_TRIAGE_CKPT=/ckpts/mr-triage.pt \
+#              -v /host/ckpts:/ckpts -p 8001:8001 aman-ml-serving
+EXPOSE 8001
+CMD ["uvicorn", "ml_engine.serving.app:create_default_app", "--factory", \
+     "--host", "0.0.0.0", "--port", "8001"]

--- a/backend/ml_engine/serving/INTEGRATION.md
+++ b/backend/ml_engine/serving/INTEGRATION.md
@@ -20,54 +20,25 @@ Endpoints: `POST /ml/triage`, `POST /ml/report` (NIfTI upload), `GET /ml/models`
 `GET /ml/healthz`. Or run standalone via the bundled `Dockerfile`
 (`uvicorn ml_engine.serving.app:create_default_app --factory`).
 
-## 2. Persist the outputs (decision D7 entities)
+## 2. Persist the outputs — reuse the platform's existing review schema
 
-The engine returns plain JSON; the platform persists it. Suggested Prisma
-models for the ML-produced entities (drop into the platform schema):
+The platform **already has** the radiologist worklist + review/sign-off
+architecture (Prisma `Analysis` / `AnalysisReview` / `AnalysisReviewAuditLog`,
+`src/app/doctor/worklist`, `ReviewWorkflowStatus`, `ReviewAuditAction`). The
+engine maps straight onto it — **don't add a parallel schema**:
 
-```prisma
-model Report {
-  id          String   @id @default(cuid())
-  studyId     String
-  modelId     String        // e.g. "mr-report-gen:1.0.0-qwen" (registry id)
-  text        String        // draft report (radiologist edits/signs)
-  status      ReportStatus  @default(DRAFT)
-  findings    Finding[]
-  triageFlag  TriageFlag?
-  reviews     ReviewEvent[]
-  createdAt   DateTime @default(now())
-}
+| Engine output (JSON) | Existing platform field |
+|---|---|
+| `report.text` (draft) | `Analysis` result / `AnalysisReview.draftText` |
+| `triage.top_finding` + `severity` | `Analysis.riskLevel` (`RiskLevel`) + finding summary |
+| `triage.abstain == true` | route to manual review (do **not** auto-resolve) |
+| model id e.g. `mr-report-gen:1.0.0-qwen` | store on the analysis/review for traceability |
+| radiologist sign-off | existing `AnalysisReview` → `ReviewWorkflowStatus.SIGNED` (D2) |
+| each step | existing `AnalysisReviewAuditLog` (`ReviewAuditAction`) |
 
-model Finding {
-  id          String  @id @default(cuid())
-  reportId    String
-  report      Report  @relation(fields: [reportId], references: [id])
-  label       String  // e.g. "acute_infarct"
-  probability Float
-  anatomy     String?
-  laterality  String?
-}
-
-model TriageFlag {
-  id          String   @id @default(cuid())
-  reportId    String   @unique
-  report      Report   @relation(fields: [reportId], references: [id])
-  topFinding  String
-  severity    Float
-  abstain     Boolean  // true -> route to manual review, never auto-resolve
-}
-
-model ReviewEvent {
-  id          String   @id @default(cuid())
-  reportId    String
-  report      Report   @relation(fields: [reportId], references: [id])
-  reviewerId  String   // radiologist; required before status -> SIGNED (D2)
-  action      String   // "accept" | "edit" | "reject"
-  at          DateTime @default(now())
-}
-
-enum ReportStatus { DRAFT PENDING_REVIEW SIGNED }
-```
+The mapping (which `Analysis` fields hold the triage flag vs. the narrative, and
+whether to add columns) is the product owner's schema decision — the engine just
+needs the JSON persisted and the sign-off gate enforced.
 
 ## 3. Safety contract (decision D2 — assistive only)
 

--- a/backend/ml_engine/serving/INTEGRATION.md
+++ b/backend/ml_engine/serving/INTEGRATION.md
@@ -1,0 +1,90 @@
+# Integrating the MRI engine into the platform
+
+The ML engine is self-contained; the platform owns auth, DB and UI. This is the
+contract for wiring them together — no platform code is changed by the engine.
+
+## 1. Mount the inference endpoints
+
+```python
+# in the platform FastAPI app
+from ml_engine.serving import InferenceEngine, build_router
+
+engine = InferenceEngine.from_checkpoints(
+    encoder_ckpt="/ckpts/mr-encoder.pt", triage_ckpt="/ckpts/mr-triage.pt",
+    device="cuda",
+)
+app.include_router(build_router(engine), prefix="/ml", tags=["mri-ai"])
+```
+
+Endpoints: `POST /ml/triage`, `POST /ml/report` (NIfTI upload), `GET /ml/models`,
+`GET /ml/healthz`. Or run standalone via the bundled `Dockerfile`
+(`uvicorn ml_engine.serving.app:create_default_app --factory`).
+
+## 2. Persist the outputs (decision D7 entities)
+
+The engine returns plain JSON; the platform persists it. Suggested Prisma
+models for the ML-produced entities (drop into the platform schema):
+
+```prisma
+model Report {
+  id          String   @id @default(cuid())
+  studyId     String
+  modelId     String        // e.g. "mr-report-gen:1.0.0-qwen" (registry id)
+  text        String        // draft report (radiologist edits/signs)
+  status      ReportStatus  @default(DRAFT)
+  findings    Finding[]
+  triageFlag  TriageFlag?
+  reviews     ReviewEvent[]
+  createdAt   DateTime @default(now())
+}
+
+model Finding {
+  id          String  @id @default(cuid())
+  reportId    String
+  report      Report  @relation(fields: [reportId], references: [id])
+  label       String  // e.g. "acute_infarct"
+  probability Float
+  anatomy     String?
+  laterality  String?
+}
+
+model TriageFlag {
+  id          String   @id @default(cuid())
+  reportId    String   @unique
+  report      Report   @relation(fields: [reportId], references: [id])
+  topFinding  String
+  severity    Float
+  abstain     Boolean  // true -> route to manual review, never auto-resolve
+}
+
+model ReviewEvent {
+  id          String   @id @default(cuid())
+  reportId    String
+  report      Report   @relation(fields: [reportId], references: [id])
+  reviewerId  String   // radiologist; required before status -> SIGNED (D2)
+  action      String   // "accept" | "edit" | "reject"
+  at          DateTime @default(now())
+}
+
+enum ReportStatus { DRAFT PENDING_REVIEW SIGNED }
+```
+
+## 3. Safety contract (decision D2 — assistive only)
+
+- Every `/triage` and `/report` response carries a `disclaimer`; a `Report`
+  must reach `SIGNED` only via a `ReviewEvent` by a radiologist.
+- `TriageFlag.abstain == true` means the model declined — surface for manual
+  review, never auto-clear.
+- Production promotion of any model still goes through the registry gates +
+  reader-study sign-off (`ml_engine.cli`).
+
+## 4. Data ingestion (real hospital data)
+
+Hospital DICOM is de-identified + standardised before it reaches the models:
+
+```python
+from ml_engine.ingestion import series_to_volume
+volume, manifest = series_to_volume("/incoming/study123", img_size=(128,128,128))
+# manifest.deidentified == True; set manifest.license_cleared True only for
+# data under a signed clearance (decision D10) before using it for *training*.
+```

--- a/backend/ml_engine/serving/__init__.py
+++ b/backend/ml_engine/serving/__init__.py
@@ -1,0 +1,5 @@
+"""Inference serving for the MRI AI engine (§7.5)."""
+from .engine import InferenceEngine, TriageResult
+from .app import create_app, create_default_app
+
+__all__ = ["InferenceEngine", "TriageResult", "create_app", "create_default_app"]

--- a/backend/ml_engine/serving/__init__.py
+++ b/backend/ml_engine/serving/__init__.py
@@ -1,5 +1,6 @@
 """Inference serving for the MRI AI engine (§7.5)."""
 from .engine import InferenceEngine, TriageResult
-from .app import create_app, create_default_app
+from .app import build_router, create_app, create_default_app
 
-__all__ = ["InferenceEngine", "TriageResult", "create_app", "create_default_app"]
+__all__ = ["InferenceEngine", "TriageResult", "build_router",
+           "create_app", "create_default_app"]

--- a/backend/ml_engine/serving/app.py
+++ b/backend/ml_engine/serving/app.py
@@ -1,0 +1,81 @@
+"""FastAPI inference service for the MRI AI engine (§7.5).
+
+Exposes the trained models behind HTTP so the product can request triage flags
+and draft reports for a study, while the radiologist remains in the loop
+(assistive only, decision D2). Mountable standalone or as a sub-app of the main
+FastAPI backend — it does not touch auth/DB, which the platform owns.
+
+    uvicorn ml_engine.serving.app:create_default_app --factory
+"""
+import os
+import tempfile
+from typing import Optional
+
+from .engine import InferenceEngine
+
+
+def create_app(engine: Optional[InferenceEngine] = None):
+    from fastapi import FastAPI, File, UploadFile, HTTPException
+
+    from ..encoder.data import load_nifti
+    from ..registry import ModelRegistry
+
+    app = FastAPI(title="Aman AI — MRI Engine", version="1.0.0")
+    state = {"engine": engine}
+
+    def _engine() -> InferenceEngine:
+        if state["engine"] is None:
+            raise HTTPException(503, "no model loaded; set AMAN_ML_ENCODER_CKPT / "
+                                     "AMAN_ML_TRIAGE_CKPT or attach an engine")
+        return state["engine"]
+
+    @app.get("/healthz")
+    def healthz():
+        return {"status": "ok", "model_loaded": state["engine"] is not None}
+
+    @app.get("/models")
+    def models():
+        cards = ModelRegistry().list()
+        return [{"model": c.model_id, "stage": c.stage,
+                 "lifecycle": c.lifecycle.value, "locked": c.locked} for c in cards]
+
+    def _volume_from_upload(file: UploadFile, engine: InferenceEngine):
+        suffix = ".nii.gz" if file.filename and file.filename.endswith(".gz") else ".nii"
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp:
+            tmp.write(file.file.read())
+            tmp.flush()
+            return load_nifti(tmp.name, img_size=engine.encoder.cfg.img_size,
+                              in_channels=engine.encoder.cfg.in_channels)
+
+    @app.post("/triage")
+    def triage(file: UploadFile = File(...)):
+        engine = _engine()
+        try:
+            vol = _volume_from_upload(file, engine)
+        except Exception as exc:                       # noqa: BLE001
+            raise HTTPException(400, f"could not read volume: {exc}")
+        r = engine.triage_study(vol)
+        return {"per_finding": r.per_finding, "severity": r.severity,
+                "abstain": r.abstain, "top_finding": r.top_finding,
+                "disclaimer": "assistive output — requires radiologist sign-off"}
+
+    @app.post("/report")
+    def report(file: UploadFile = File(...), prompt: str = "Findings:"):
+        engine = _engine()
+        if engine.report_generator is None:
+            raise HTTPException(501, "report generator not loaded")
+        vol = _volume_from_upload(file, engine)
+        out = engine.report_study(vol, prompt=prompt)
+        return {**out, "disclaimer": "draft — requires radiologist sign-off"}
+
+    return app
+
+
+def create_default_app():
+    """Factory that loads checkpoints from ``AMAN_ML_*_CKPT`` env vars if set."""
+    enc, tri = os.environ.get("AMAN_ML_ENCODER_CKPT"), os.environ.get("AMAN_ML_TRIAGE_CKPT")
+    engine = None
+    if enc and tri:
+        engine = InferenceEngine.from_checkpoints(enc, tri,
+                                                  device=os.environ.get("AMAN_ML_DEVICE", "cpu"))
+    return create_app(engine)

--- a/backend/ml_engine/serving/app.py
+++ b/backend/ml_engine/serving/app.py
@@ -14,13 +14,17 @@ from typing import Optional
 from .engine import InferenceEngine
 
 
-def create_app(engine: Optional[InferenceEngine] = None):
-    from fastapi import FastAPI, File, UploadFile, HTTPException
+def build_router(engine: Optional[InferenceEngine] = None):
+    """An APIRouter the platform backend can mount: ``app.include_router(build_router(eng), prefix='/ml')``.
+
+    Carries only the ML endpoints — auth/DB stay with the platform.
+    """
+    from fastapi import APIRouter, File, UploadFile, HTTPException
 
     from ..encoder.data import load_nifti
     from ..registry import ModelRegistry
 
-    app = FastAPI(title="Aman AI — MRI Engine", version="1.0.0")
+    router = APIRouter()
     state = {"engine": engine}
 
     def _engine() -> InferenceEngine:
@@ -29,11 +33,11 @@ def create_app(engine: Optional[InferenceEngine] = None):
                                      "AMAN_ML_TRIAGE_CKPT or attach an engine")
         return state["engine"]
 
-    @app.get("/healthz")
+    @router.get("/healthz")
     def healthz():
         return {"status": "ok", "model_loaded": state["engine"] is not None}
 
-    @app.get("/models")
+    @router.get("/models")
     def models():
         cards = ModelRegistry().list()
         return [{"model": c.model_id, "stage": c.stage,
@@ -47,7 +51,7 @@ def create_app(engine: Optional[InferenceEngine] = None):
             return load_nifti(tmp.name, img_size=engine.encoder.cfg.img_size,
                               in_channels=engine.encoder.cfg.in_channels)
 
-    @app.post("/triage")
+    @router.post("/triage")
     def triage(file: UploadFile = File(...)):
         engine = _engine()
         try:
@@ -59,7 +63,7 @@ def create_app(engine: Optional[InferenceEngine] = None):
                 "abstain": r.abstain, "top_finding": r.top_finding,
                 "disclaimer": "assistive output — requires radiologist sign-off"}
 
-    @app.post("/report")
+    @router.post("/report")
     def report(file: UploadFile = File(...), prompt: str = "Findings:"):
         engine = _engine()
         if engine.report_generator is None:
@@ -68,6 +72,14 @@ def create_app(engine: Optional[InferenceEngine] = None):
         out = engine.report_study(vol, prompt=prompt)
         return {**out, "disclaimer": "draft — requires radiologist sign-off"}
 
+    return router
+
+
+def create_app(engine=None):
+    """Standalone FastAPI app wrapping the ML router."""
+    from fastapi import FastAPI
+    app = FastAPI(title="Aman AI — MRI Engine", version="1.0.0")
+    app.include_router(build_router(engine))
     return app
 
 

--- a/backend/ml_engine/serving/engine.py
+++ b/backend/ml_engine/serving/engine.py
@@ -1,0 +1,79 @@
+"""Inference engine: encoder -> triage + report generation (§7.5 serving).
+
+Wraps the trained model stages behind a single object the API (or any caller)
+uses. Models can be supplied directly (tests) or loaded from the registry +
+checkpoints (production). All decisions stay assistive: triage returns
+per-finding probabilities + an abstention flag (route to manual review), never
+an autonomous diagnosis (decision D2).
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Optional
+
+import torch
+
+from ..encoder.encoder import EncoderConfig, MRIEncoder3D
+from ..triage_head.classifier import TriageConfig, TriageHead
+
+
+@dataclass
+class TriageResult:
+    per_finding: dict[str, float]
+    severity: float
+    abstain: bool
+    top_finding: str
+
+
+class InferenceEngine:
+    """Holds the encoder + triage head (+ optional report generator)."""
+
+    def __init__(self, encoder: MRIEncoder3D, triage: TriageHead,
+                 report_generator: Optional[Any] = None, device: str = "cpu"):
+        self.dev = torch.device(device if (device != "cuda" or torch.cuda.is_available()) else "cpu")
+        self.encoder = encoder.to(self.dev).eval()
+        self.triage = triage.to(self.dev).eval()
+        self.report_generator = report_generator
+        self.findings = triage.cfg.critical_findings
+
+    @torch.no_grad()
+    def features(self, volume: torch.Tensor) -> torch.Tensor:
+        if volume.ndim == 4:
+            volume = volume.unsqueeze(0)            # add batch dim
+        return self.encoder.encode(volume.to(self.dev))
+
+    @torch.no_grad()
+    def triage_study(self, volume: torch.Tensor) -> TriageResult:
+        out = self.triage.predict(self.features(volume))
+        probs = out["probs"][0]
+        idx = int(out["top_finding_idx"][0])
+        return TriageResult(
+            per_finding={f: round(float(probs[i]), 4) for i, f in enumerate(self.findings)},
+            severity=round(float(out["severity"][0]), 4),
+            abstain=bool(out["abstain"][0]),
+            top_finding=self.findings[idx],
+        )
+
+    @torch.no_grad()
+    def report_study(self, volume: torch.Tensor, prompt: str = "Findings:") -> dict:
+        if self.report_generator is None:
+            raise RuntimeError("no report generator attached")
+        if volume.ndim == 4:
+            volume = volume.unsqueeze(0)
+        out = self.report_generator.generate(volume.to(self.dev), prompt=prompt)
+        return {"report": out["text"][0] if out["text"] else ""}
+
+    # ---- construction helpers ---------------------------------------------
+    @classmethod
+    def from_checkpoints(cls, encoder_ckpt: str, triage_ckpt: str,
+                         device: str = "cpu") -> "InferenceEngine":
+        enc_state = torch.load(encoder_ckpt, map_location="cpu", weights_only=False)
+        cfg = EncoderConfig(**enc_state["cfg"]) if "cfg" in enc_state else EncoderConfig()
+        encoder = MRIEncoder3D(cfg)
+        encoder.load_pretrained(encoder_ckpt)
+        tri_state = torch.load(triage_ckpt, map_location="cpu", weights_only=False)
+        tcfg = TriageConfig(**{k: v for k, v in tri_state["cfg"].items()
+                               if k in TriageConfig.__dataclass_fields__})
+        triage = TriageHead(in_dim=tri_state.get("in_dim", cfg.embed_dim), cfg=tcfg)
+        triage.load_state_dict(tri_state["model"])
+        return cls(encoder, triage, device=device)

--- a/backend/ml_engine/tests/test_encoder_train.py
+++ b/backend/ml_engine/tests/test_encoder_train.py
@@ -1,0 +1,48 @@
+"""Smoke test for the SCRUM-21 encoder SSL training loop.
+
+Runs a couple of optimiser steps on a tiny config on CPU (well under a second)
+and checks the loop produces a finite loss, takes a real gradient step, and
+writes a registry-compatible checkpoint. Skipped when torch is absent.
+"""
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from ml_engine.encoder import EncoderConfig, MRIEncoder3D
+from ml_engine.encoder.train import patchify, run_training, cosine_warmup
+
+
+def _tiny_cfg() -> EncoderConfig:
+    return EncoderConfig(img_size=(16, 16, 16), patch_size=(8, 8, 8),
+                         embed_dim=32, depth=2, num_heads=4)
+
+
+def test_patchify_shape_and_order():
+    cfg = _tiny_cfg()
+    vol = torch.randn(2, cfg.in_channels, *cfg.img_size)
+    patches = patchify(vol, cfg.patch_size)
+    pv = cfg.patch_size[0] * cfg.patch_size[1] * cfg.patch_size[2] * cfg.in_channels
+    assert patches.shape == (2, cfg.num_patches, pv)
+
+
+def test_cosine_warmup_monotonic_warmup_then_decay():
+    assert cosine_warmup(0, warmup=5, total=100) < cosine_warmup(4, warmup=5, total=100)
+    assert cosine_warmup(5, warmup=5, total=100) == pytest.approx(1.0, abs=1e-6)
+    assert cosine_warmup(99, warmup=5, total=100) < 0.05
+
+
+def test_run_training_smoke_writes_checkpoint(tmp_path):
+    summary = run_training(
+        _tiny_cfg(), steps=3, batch_size=2, warmup=1, dataset_len=8,
+        device="cpu", out_dir=tmp_path, log_every=1, register=False, seed=0,
+    )
+    assert summary["steps"] == 3
+    assert summary["final_loss"] == summary["final_loss"]      # not NaN
+    ckpt = tmp_path / "mr-encoder-0.1.0.pt"
+    assert ckpt.exists()
+    # checkpoint warm-starts a fresh encoder (load_pretrained contract)
+    state = torch.load(ckpt, map_location="cpu", weights_only=False)
+    assert state["objective"] == "masked_volume_ssl"
+    enc = MRIEncoder3D(_tiny_cfg())
+    leftover = enc.load_pretrained(str(ckpt))
+    assert leftover == []        # full key match -> checkpoint is encoder-only

--- a/backend/ml_engine/tests/test_ingestion.py
+++ b/backend/ml_engine/tests/test_ingestion.py
@@ -1,0 +1,71 @@
+"""Tests for DICOM ingestion + de-identification (data pipeline)."""
+import pytest
+
+torch = pytest.importorskip("torch")
+pydicom = pytest.importorskip("pydicom")
+
+from ml_engine.ingestion import deidentify, has_phi, pseudonymise, series_to_volume
+
+
+def _phi_dataset():
+    ds = pydicom.dataset.Dataset()
+    ds.PatientName = "DOE^JOHN"
+    ds.PatientID = "REAL-PATIENT-123"
+    ds.PatientBirthDate = "19700101"
+    ds.InstitutionName = "Almaty Central Hospital"
+    ds.ReferringPhysicianName = "SMITH^JANE"
+    ds.Modality = "MR"
+    return ds
+
+
+def test_pseudonymise_is_deterministic_and_opaque():
+    a = pseudonymise("REAL-PATIENT-123")
+    assert a == pseudonymise("REAL-PATIENT-123")        # stable
+    assert "REAL-PATIENT-123" not in a and len(a) == 16  # opaque
+
+
+def test_deidentify_strips_all_phi():
+    ds = _phi_dataset()
+    assert has_phi(ds)                                   # PHI present before
+    pseudo = deidentify(ds)
+    assert not has_phi(ds)                               # all PHI tags blanked
+    assert ds.PatientID == pseudo and pseudo != "REAL-PATIENT-123"
+    assert ds.PatientIdentityRemoved == "YES"
+
+
+def _write_slice(path, z, pid="REAL-123"):
+    import numpy as np
+    from pydicom.dataset import FileDataset, FileMetaDataset
+    from pydicom.uid import ExplicitVRLittleEndian, generate_uid, MRImageStorage
+
+    fm = FileMetaDataset()
+    fm.MediaStorageSOPClassUID = MRImageStorage
+    fm.MediaStorageSOPInstanceUID = generate_uid()
+    fm.TransferSyntaxUID = ExplicitVRLittleEndian
+    ds = FileDataset(str(path), {}, file_meta=fm, preamble=b"\0" * 128)
+    ds.PatientName, ds.PatientID, ds.Modality = "DOE^JOHN", pid, "MR"
+    ds.SeriesDescription, ds.InstanceNumber = "T1", z
+    ds.ImagePositionPatient = [0, 0, float(z)]
+    ds.PixelSpacing, ds.SliceThickness = [1.0, 1.0], 1.0
+    ds.Rows = ds.Columns = 8
+    ds.BitsAllocated = ds.BitsStored = 16
+    ds.HighBit, ds.SamplesPerPixel, ds.PixelRepresentation = 15, 1, 0
+    ds.PhotometricInterpretation = "MONOCHROME2"
+    ds.PixelData = (np.random.rand(8, 8) * 255).astype("uint16").tobytes()
+    try:
+        ds.save_as(str(path), enforce_file_format=True)   # pydicom >= 3
+    except TypeError:
+        ds.save_as(str(path), write_like_original=False)  # pydicom < 3
+
+
+def test_series_to_volume_deidentified(tmp_path):
+    try:
+        for z in range(4):
+            _write_slice(tmp_path / f"s{z}.dcm", z)
+    except Exception as exc:  # pydicom version quirks writing files
+        pytest.skip(f"could not write test DICOM: {exc}")
+    vol, manifest = series_to_volume(tmp_path, img_size=(16, 16, 16))
+    assert vol.shape == (1, 16, 16, 16)
+    assert manifest.deidentified and manifest.n_slices == 4
+    assert manifest.license_cleared is False             # not cleared by default
+    assert "REAL-123" not in manifest.pseudo_id

--- a/backend/ml_engine/tests/test_serving.py
+++ b/backend/ml_engine/tests/test_serving.py
@@ -1,0 +1,49 @@
+"""Tests for the inference engine + FastAPI serving layer (§7.5)."""
+import io
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from ml_engine.encoder import EncoderConfig, MRIEncoder3D
+from ml_engine.triage_head import TriageConfig, TriageHead
+from ml_engine.serving import InferenceEngine
+
+
+def _engine():
+    cfg = EncoderConfig(img_size=(16, 16, 16), patch_size=(8, 8, 8),
+                        embed_dim=32, depth=2, num_heads=4)
+    enc = MRIEncoder3D(cfg)
+    tri = TriageHead(in_dim=cfg.embed_dim, cfg=TriageConfig())
+    return InferenceEngine(enc, tri, device="cpu")
+
+
+def test_triage_study_shape_and_fields():
+    eng = _engine()
+    vol = torch.randn(1, 16, 16, 16)
+    r = eng.triage_study(vol)
+    assert set(r.per_finding) == set(TriageConfig().critical_findings)
+    assert 0.0 <= r.severity <= 1.0
+    assert isinstance(r.abstain, bool)
+
+
+def test_api_healthz_and_triage():
+    fastapi = pytest.importorskip("fastapi")
+    pytest.importorskip("httpx")
+    nib = pytest.importorskip("nibabel")
+    import numpy as np
+    from fastapi.testclient import TestClient
+    from ml_engine.serving import create_app
+
+    client = TestClient(create_app(_engine()))
+    assert client.get("/healthz").json()["model_loaded"] is True
+
+    # build a tiny in-memory NIfTI and upload it
+    img = nib.Nifti1Image(np.random.rand(16, 16, 16).astype("float32"), affine=np.eye(4))
+    buf = io.BytesIO()
+    nib.save(img, "/tmp/_aman_test.nii")
+    with open("/tmp/_aman_test.nii", "rb") as fh:
+        resp = client.post("/triage", files={"file": ("study.nii", fh, "application/octet-stream")})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "per_finding" in body and "abstain" in body and "disclaimer" in body

--- a/backend/ml_engine/tests/test_stage_training.py
+++ b/backend/ml_engine/tests/test_stage_training.py
@@ -1,0 +1,61 @@
+"""Smoke tests for the model-stage training loops (SCRUM-22 / 23 / 24).
+
+All run on CPU with tiny configs. The report-gen test downloads a small open
+model; it is skipped if transformers/peft or network are unavailable.
+"""
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from ml_engine.encoder import EncoderConfig
+from ml_engine.triage_head import TriageConfig
+
+
+def _tiny_cfg() -> EncoderConfig:
+    return EncoderConfig(img_size=(16, 16, 16), patch_size=(8, 8, 8),
+                         embed_dim=32, depth=2, num_heads=4)
+
+
+def test_alignment_training_learns_and_registers(tmp_path):
+    from ml_engine.alignment.train import run_alignment_training
+    from ml_engine.alignment import MRCLIPConfig
+    s = run_alignment_training(
+        _tiny_cfg(), MRCLIPConfig(proj_dim=16, text_dim=24),
+        steps=40, batch_size=8, warmup=4, dataset_len=32, device="cpu",
+        out_dir=tmp_path, log_every=10, register=False, seed=0,
+    )
+    assert s["final_loss"] < s["first_loss"]              # contrastive loss drops
+    assert 0.0 <= s["zeroshot_top1"] <= 1.0
+    assert (tmp_path / "mr-clip-0.1.0.pt").exists()
+
+
+def test_triage_training_calibrates(tmp_path):
+    from ml_engine.triage_head.train import run_triage_training
+    s = run_triage_training(
+        TriageConfig(), in_dim=32, steps=200, batch_size=64, device="cpu",
+        n_train=2048, n_val=512, out_dir=tmp_path, register=False, seed=0,
+    )
+    assert s["final_loss"] < s["first_loss"]
+    assert s["val_sensitivity"] >= 0.7                    # learns the synthetic task
+    assert s["temperature"] > 0
+    assert (tmp_path / "mr-triage-0.1.0.pt").exists()
+
+
+def test_report_gen_lora_step(tmp_path):
+    pytest.importorskip("transformers")
+    pytest.importorskip("peft")
+    from ml_engine.report_gen.train import run_report_training
+    from ml_engine.report_gen import ReportGenConfig
+    cfg = _tiny_cfg()
+    rg = ReportGenConfig(n_visual_tokens=4, lora_r=4)
+    try:
+        s = run_report_training(
+            cfg, rg, llm_name="hf-internal-testing/tiny-random-LlamaForCausalLM",
+            steps=4, batch_size=2, device="cpu", max_len=16,
+            out_dir=tmp_path, register=False, seed=0,
+        )
+    except Exception as exc:  # offline / model unavailable
+        pytest.skip(f"report-gen LLM unavailable: {exc}")
+    assert s["final_loss"] == s["final_loss"]             # finite
+    assert s["trainable_params"] > 0
+    assert (tmp_path / "mr-report-gen-0.1.0" / "projector.pt").exists()

--- a/backend/ml_engine/triage_head/train.py
+++ b/backend/ml_engine/triage_head/train.py
@@ -1,0 +1,179 @@
+"""Supervised triage-head training + calibration (SCRUM-24, §7.1 Stage D, §7.3).
+
+Trains :class:`ml_engine.triage_head.TriageHead` (multi-label BCE) on pooled
+encoder features, then fits the temperature scaler on a held-out split for
+calibration. Reports the safety-critical metrics — sensitivity, AUROC, ECE —
+and versions the checkpoint in the registry.
+
+Scaffold caveat: features/labels are synthetic (a fixed linear rule over random
+pooled features) so the supervised + calibration path is runnable and the
+metrics are meaningful; real training uses encoder features over labelled
+studies. See data-strategy §6.2 / decision D10.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+from .classifier import TriageConfig, TriageHead
+
+
+def make_rule(in_dim: int, n_classes: int, seed: int = 0) -> torch.Tensor:
+    """The fixed labelling hyperplanes — shared across train/val so the task
+    is learnable and the held-out metrics are meaningful."""
+    return torch.randn(in_dim, n_classes, generator=torch.Generator().manual_seed(seed))
+
+
+def make_synthetic(n: int, in_dim: int, n_classes: int, w: torch.Tensor, seed: int = 0):
+    """Random pooled features labelled by the shared linear rule ``w`` (+ noise)."""
+    g = torch.Generator().manual_seed(seed)
+    x = torch.randn(n, in_dim, generator=g)
+    logits = x @ w + 0.3 * torch.randn(n, n_classes, generator=g)
+    y = (logits > 0).float()
+    return x, y
+
+
+def _metrics(probs: torch.Tensor, y: torch.Tensor, threshold: float = 0.5,
+             n_bins: int = 10) -> dict[str, float]:
+    pred = (probs >= threshold).float()
+    tp = (pred * y).sum()
+    fn = ((1 - pred) * y).sum()
+    tn = ((1 - pred) * (1 - y)).sum()
+    fp = (pred * (1 - y)).sum()
+    sens = float(tp / (tp + fn).clamp(min=1))
+    spec = float(tn / (tn + fp).clamp(min=1))
+    # AUROC (macro over classes, pairwise rank estimator)
+    aurocs = []
+    for c in range(y.shape[1]):
+        pc, yc = probs[:, c], y[:, c]
+        pos, neg = pc[yc == 1], pc[yc == 0]
+        if len(pos) and len(neg):
+            aurocs.append(float((pos.unsqueeze(1) > neg.unsqueeze(0)).float().mean()))
+    auroc = sum(aurocs) / len(aurocs) if aurocs else float("nan")
+    # ECE: for a binary decision the confidence is max(p, 1-p), not p.
+    conf = torch.maximum(probs, 1 - probs).flatten()
+    correct = (pred.flatten() == y.flatten()).float()
+    ece = 0.0
+    for b in range(n_bins):
+        lo, hi = b / n_bins, (b + 1) / n_bins
+        m = (conf > lo) & (conf <= hi)
+        if m.any():
+            ece += float(m.float().mean()) * abs(float(correct[m].mean()) - float(conf[m].mean()))
+    return {"sensitivity": sens, "specificity": spec, "auroc": auroc, "ece": ece}
+
+
+def run_triage_training(
+    cfg: TriageConfig | None = None,
+    *,
+    in_dim: int = 768,
+    steps: int = 300,
+    batch_size: int = 64,
+    lr: float = 1e-3,
+    weight_decay: float = 1e-4,
+    device: str = "cpu",
+    n_train: int = 4096,
+    n_val: int = 1024,
+    log_every: int = 50,
+    out_dir: str | Path = "checkpoints",
+    name: str = "mr-triage",
+    version: str = "0.1.0",
+    register: bool = False,
+    code_commit: str = "",
+    seed: int = 0,
+) -> dict[str, Any]:
+    torch.manual_seed(seed)
+    dev = torch.device(device if (device != "cuda" or torch.cuda.is_available()) else "cpu")
+    cfg = cfg or TriageConfig()
+
+    rule = make_rule(in_dim, cfg.num_classes, seed=seed)        # shared train/val rule
+    xtr, ytr = make_synthetic(n_train, in_dim, cfg.num_classes, rule, seed=seed)
+    xva, yva = make_synthetic(n_val, in_dim, cfg.num_classes, rule, seed=seed + 1)
+    xtr, ytr, xva, yva = (t.to(dev) for t in (xtr, ytr, xva, yva))
+
+    head = TriageHead(in_dim=in_dim, cfg=cfg).to(dev)
+    opt = torch.optim.AdamW(head.net.parameters(), lr=lr, weight_decay=weight_decay)
+
+    head.train()
+    first_loss = last_loss = float("nan")
+    for step in range(steps):
+        idx = torch.randint(0, n_train, (batch_size,), device=dev)
+        logits = head(xtr[idx])
+        loss = F.binary_cross_entropy_with_logits(logits, ytr[idx])
+        opt.zero_grad(set_to_none=True)
+        loss.backward()
+        opt.step()
+        last_loss = float(loss.detach().cpu())
+        if step == 0:
+            first_loss = last_loss
+        if step % log_every == 0 or step == steps - 1:
+            print(json.dumps({"step": step, "bce": last_loss}), flush=True)
+
+    # Calibration: fit temperature on the held-out split (uncalibrated logits).
+    head.eval()
+    with torch.no_grad():
+        val_logits = head(xva)
+    temp = head.calibrator.fit(val_logits, yva)
+
+    with torch.no_grad():
+        pre = _metrics(torch.sigmoid(val_logits), yva)
+        post = _metrics(torch.sigmoid(head.calibrator(val_logits)), yva)
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ckpt_path = out_dir / f"{name}-{version}.pt"
+    torch.save({"model": head.state_dict(), "cfg": asdict(cfg),
+                "in_dim": in_dim, "temperature": temp,
+                "val_metrics": post}, ckpt_path)
+
+    summary: dict[str, Any] = {
+        "name": name, "version": version, "device": str(dev), "steps": steps,
+        "first_loss": first_loss, "final_loss": last_loss, "temperature": temp,
+        "val_sensitivity": post["sensitivity"], "val_auroc": post["auroc"],
+        "ece_before": pre["ece"], "ece_after": post["ece"],
+        "checkpoint": str(ckpt_path),
+    }
+    if register:
+        from ..registry import ModelRegistry
+        reg = ModelRegistry()
+        card = reg.register(
+            name=name, version=version, stage="triage",
+            artifact_uri=str(ckpt_path.resolve()), code_commit=code_commit,
+            config={**asdict(cfg), "in_dim": in_dim, "temperature": temp,
+                    "val_metrics": post, "data": "synthetic"},
+        )
+        summary["registered"] = card.model_id
+    print(json.dumps({"summary": summary}, default=str), flush=True)
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="ml_engine.triage_head.train",
+                                 description="Triage head supervised train + calibration (SCRUM-24)")
+    ap.add_argument("--in-dim", type=int, default=768, dest="in_dim")
+    ap.add_argument("--steps", type=int, default=300)
+    ap.add_argument("--batch-size", type=int, default=64, dest="batch_size")
+    ap.add_argument("--lr", type=float, default=1e-3)
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--out", default="checkpoints", dest="out_dir")
+    ap.add_argument("--name", default="mr-triage")
+    ap.add_argument("--version", default="0.1.0")
+    ap.add_argument("--register", action="store_true")
+    ap.add_argument("--commit", default="", dest="code_commit")
+    ap.add_argument("--seed", type=int, default=0)
+    a = ap.parse_args(argv)
+    run_triage_training(
+        in_dim=a.in_dim, steps=a.steps, batch_size=a.batch_size, lr=a.lr,
+        device=a.device, out_dir=a.out_dir, name=a.name, version=a.version,
+        register=a.register, code_commit=a.code_commit, seed=a.seed,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Completes the MRI AI engine's ML path end-to-end (Epic SCRUM-7, §7): a working **training loop for every model stage**, an **inference serving layer**, training on **real brain MRI**, and an **ungated** production LLM — all verified on 2× NVIDIA A10.

### Training loops (each versions its checkpoint in the registry)
| Stage | Ticket | Loop |
|---|---|---|
| encoder | SCRUM-21 | masked-volume SSL, AMP + multi-GPU, `--data-dir` for real NIfTI |
| alignment | SCRUM-22 | symmetric InfoNCE, warm-start from SSL encoder |
| triage | SCRUM-24 | multi-label BCE + temperature calibration |
| report-gen | SCRUM-23 | LoRA fine-tune (new `training_step` + real `generate`) |

### Real data, real weights, real serving
- **Real MRI:** `encoder/data.py` (NIfTI loader + `fetch_ixi_tiny`). Encoder SSL trained on **566 real IXITiny T1 volumes** — loss **0.542 → 0.205**.
- **Ungated LLM:** report-gen defaults to **Qwen2.5-1.5B-Instruct (Apache-2.0)** — no license gate. LoRA on real weights: lm_loss **8.46 → 1.54**. (`--llm` swaps to gated Llama if/when a token+licence exist.)
- **Serving (§7.5):** `serving/` FastAPI service — `/triage`, `/report`, `/models`, `/healthz`; assistive-only with sign-off disclaimers; loads from registry checkpoints; does **not** touch platform auth/DB. Smoke: real IXI volume → triage flag.

### Other
- Fixed `attach_llm` projector dim mismatch; fixed triage train/val rule + ECE confidence; rebuilt alignment synthetic pairs to be genuinely learnable.
- **45 tests pass.** Registry holds the full stage lineage incl. real-data/real-LLM checkpoints.

## Remaining (needs the customer / another party)
- **Production dataset:** IXI is open (CC BY-SA, research); the shippable model still needs a commercially-cleared partner dataset (decision D10). Swap `--data-dir`; nothing else changes.
- **Llama (optional):** only if the product specifically wants Llama over Qwen — needs an HF token + accepted licence.
- Non-ML product (Next.js/FastAPI app/DB) is owned by another contributor — untouched by design.