### PR TITLE
World-class upgrades (batch 1): SimMIM SSL fix + evaluation confidence intervals + roadmap

### DIFF
--- a/backend/ml_engine/config/settings.py
+++ b/backend/ml_engine/config/settings.py
@@ -38,6 +38,10 @@ class EvalGates:
     # Triage — detection. Sensitivity gate is the safety-critical one.
     triage_sensitivity_min: float = field(default_factory=lambda: _env_float("GATE_TRIAGE_SENS", 0.95))
     triage_auroc_min: float = field(default_factory=lambda: _env_float("GATE_TRIAGE_AUROC", 0.85))
+    # Regulator-grade option: also require the sensitivity *lower confidence bound*
+    # (Clopper-Pearson) to clear a threshold. 0.0 disables it (point-estimate only).
+    triage_sensitivity_ci_lower_min: float = field(
+        default_factory=lambda: _env_float("GATE_TRIAGE_SENS_CI_LOW", 0.0))
     # Calibration — lower is better (Expected Calibration Error).
     ece_max: float = field(default_factory=lambda: _env_float("GATE_ECE_MAX", 0.10))
     # Fairness — max allowed gap between best and worst subgroup on the key metric.

--- a/backend/ml_engine/encoder/encoder.py
+++ b/backend/ml_engine/encoder/encoder.py
@@ -77,8 +77,16 @@ class MRIEncoder3D(nn.Module):
     def embed_dim(self) -> int:
         return self.cfg.embed_dim
 
-    def forward(self, x: torch.Tensor) -> dict[str, torch.Tensor]:
+    def forward(self, x: torch.Tensor, *, token_mask: torch.Tensor | None = None,
+                mask_token: torch.Tensor | None = None) -> dict[str, torch.Tensor]:
         tokens = self.patch_embed(x)
+        if token_mask is not None and mask_token is not None:
+            # SimMIM-style input masking: replace masked patch embeddings with a
+            # shared learnable mask token *before* encoding, so the encoder must
+            # infer masked content from visible context (a real SSL signal,
+            # unlike autoencoding the full volume). token_mask: (B, N), 1=masked.
+            w = token_mask.unsqueeze(-1).to(tokens.dtype)
+            tokens = tokens * (1.0 - w) + mask_token.to(tokens.dtype) * w
         cls = self.cls_token.expand(tokens.size(0), -1, -1)
         tokens = torch.cat([cls, tokens], dim=1) + self.pos_embed[:, : tokens.size(1) + 1]
         tokens = self.norm(self.blocks(tokens))
@@ -97,13 +105,23 @@ class MRIEncoder3D(nn.Module):
 
 
 class MaskedVolumeSSL(nn.Module):
-    """MAE-style masked-volume reconstruction head for SSL pretraining (Stage A)."""
+    """SimMIM-style masked-volume reconstruction head for SSL pretraining (Stage A).
+
+    Masked patches are replaced at the *input* with a learnable mask token, so the
+    encoder reconstructs them from visible context; the loss is applied on the
+    masked patches only, against per-patch-normalised targets (the standard
+    MAE/SimMIM recipe). This is a genuine self-supervised objective — earlier code
+    autoencoded the full volume and masked *after* the forward pass, which leaked
+    the answer and produced no transferable signal.
+    """
 
     def __init__(self, encoder: MRIEncoder3D):
         super().__init__()
         self.encoder = encoder
         cfg = encoder.cfg
         patch_voxels = cfg.patch_size[0] * cfg.patch_size[1] * cfg.patch_size[2] * cfg.in_channels
+        self.mask_token = nn.Parameter(torch.zeros(1, 1, cfg.embed_dim))
+        nn.init.trunc_normal_(self.mask_token, std=0.02)
         self.decoder = nn.Sequential(
             nn.Linear(cfg.embed_dim, cfg.embed_dim), nn.GELU(),
             nn.Linear(cfg.embed_dim, patch_voxels),
@@ -117,13 +135,22 @@ class MaskedVolumeSSL(nn.Module):
         mask.scatter_(1, ids[:, :keep], 0)  # 0 = visible, 1 = masked
         return mask
 
+    @staticmethod
+    def _normalize_patches(target: torch.Tensor) -> torch.Tensor:
+        """Per-patch z-score of reconstruction targets (improves MAE/SimMIM features)."""
+        mu = target.mean(dim=-1, keepdim=True)
+        var = target.var(dim=-1, keepdim=True, unbiased=False)
+        return (target - mu) / (var + 1e-6).sqrt()
+
     def forward(self, x: torch.Tensor, target_patches: torch.Tensor) -> torch.Tensor:
-        """Return reconstruction loss on masked patches.
+        """Return reconstruction loss on the masked patches only.
 
         ``target_patches``: (B, N, patch_voxels) ground-truth patch pixels.
+        The same mask drives both input corruption and the loss support.
         """
-        out = self.encoder(x)
+        mask = self.random_mask(self.encoder.cfg.num_patches, x.size(0), x.device)
+        out = self.encoder(x, token_mask=mask, mask_token=self.mask_token)
         pred = self.decoder(out["patch_tokens"])
-        mask = self.random_mask(pred.size(1), pred.size(0), pred.device)
-        loss = ((pred - target_patches) ** 2).mean(dim=-1)
-        return (loss * mask).sum() / mask.sum().clamp(min=1)
+        target = self._normalize_patches(target_patches)
+        loss = ((pred - target) ** 2).mean(dim=-1)             # (B, N)
+        return (loss * mask).sum() / mask.sum().clamp(min=1)    # masked patches only

--- a/backend/ml_engine/encoder/train.py
+++ b/backend/ml_engine/encoder/train.py
@@ -16,10 +16,10 @@ training run):
     cleared partner dataset (blocked — see vault data-strategy §6.2 / decision
     D10). Swap :class:`SyntheticMRIVolumes` for the real loader; nothing else
     in the loop changes.
-  * The current ``MaskedVolumeSSL`` encodes the *full* volume and applies the
-    reconstruction loss only on the masked patch subset (masked-target MAE),
-    rather than dropping masked tokens from the encoder input. Good enough to
-    exercise the pipeline; tighten to true input-masking before real runs.
+  * ``MaskedVolumeSSL`` now uses SimMIM-style input masking: masked patches are
+    replaced with a learnable mask token before encoding and the loss is computed
+    on the masked patches only against per-patch-normalised targets — a genuine
+    self-supervised signal (not full-volume autoencoding).
   * Linear-probe-beats-from-scratch (the 3rd acceptance criterion) is a
     downstream eval, not part of this loop — tracked as a follow-up.
 """

--- a/backend/ml_engine/evaluation/harness.py
+++ b/backend/ml_engine/evaluation/harness.py
@@ -19,8 +19,10 @@ import json
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, Sequence
 
+import numpy as np
+
 from ..registry.models import EvalReport
-from . import calibration, clinical, fairness, nlg, triage
+from . import calibration, clinical, fairness, nlg, stats, triage
 
 SAMPLE_SCHEMA_DOC = """
 Each sample is a dict with (all keys optional except study_id):
@@ -47,6 +49,10 @@ class EvalConfig:
     calibration_bins: int = 10
     label_set: Optional[Sequence[str]] = None
     green_grader: Optional[Callable[[str, str], float]] = None
+    # Statistical rigor: confidence intervals on the headline metrics.
+    ci_alpha: float = 0.05            # 95% CIs
+    bootstrap_n: int = 1000           # bootstrap resamples for AUROC CI
+    bootstrap_seed: int = 0           # reproducible bootstrap
 
 
 class EvalHarness:
@@ -106,6 +112,29 @@ class EvalHarness:
                 y_true, y_score, cfg.triage_threshold, ttf if any(ttf) else None))
             metrics.update(calibration.all_calibration_metrics(
                 y_true, y_score, cfg.calibration_bins))
+
+            # ---- statistical rigor: CIs on the safety-critical metrics -------
+            # Sensitivity gets an exact (Clopper-Pearson) interval; AUROC a
+            # percentile bootstrap. Regulators/reviewers judge the lower bound,
+            # not a point estimate (see registry gates for the optional CI gate).
+            yt_arr = np.asarray(y_true, dtype=int)
+            ys_arr = np.asarray(y_score, dtype=float)
+            n_pos = int(yt_arr.sum())
+            tp = int(((yt_arr == 1) & (ys_arr >= cfg.triage_threshold)).sum())
+            sens_lo, sens_hi = stats.clopper_pearson(tp, n_pos, alpha=cfg.ci_alpha)
+            metrics["triage.sensitivity_ci_low"] = sens_lo
+            metrics["triage.sensitivity_ci_high"] = sens_hi
+            metrics["triage.n"] = float(len(yt_arr))
+            metrics["triage.n_positive"] = float(n_pos)
+
+            def _auroc_on(idx: np.ndarray) -> float:
+                return triage.auroc(yt_arr[idx].tolist(), ys_arr[idx].tolist())
+
+            _, au_lo, au_hi = stats.bootstrap_ci(
+                _auroc_on, len(yt_arr), n_boot=cfg.bootstrap_n,
+                alpha=cfg.ci_alpha, seed=cfg.bootstrap_seed)
+            metrics["triage.auroc_ci_low"] = au_lo
+            metrics["triage.auroc_ci_high"] = au_hi
 
             # ---- fairness: triage sensitivity per subgroup ------------------
             thr = cfg.triage_threshold

--- a/backend/ml_engine/evaluation/stats.py
+++ b/backend/ml_engine/evaluation/stats.py
@@ -1,0 +1,91 @@
+"""Statistical-rigor utilities for evaluation (SCRUM-26, §7.3).
+
+Point estimates are not enough for a clinical / regulator / journal-grade
+evaluation: every headline metric needs an uncertainty interval, and the
+safety-critical **sensitivity** gate should be judged on a *lower confidence
+bound*, not a lucky point estimate.
+
+This module provides, dependency-light (numpy + stdlib; scipy used only if it
+happens to be installed):
+  * :func:`clopper_pearson` — exact binomial CI for a proportion (sensitivity,
+    specificity); the standard "exact" interval regulators expect.
+  * :func:`wilson_interval` — closed-form score interval (no scipy), used as the
+    Clopper-Pearson fallback and a good default for proportions.
+  * :func:`bootstrap_ci` — percentile bootstrap CI for any statistic (AUROC,
+    accuracy, NLG metrics) over resampled cases.
+"""
+from __future__ import annotations
+
+import math
+import statistics
+from typing import Callable
+
+import numpy as np
+
+
+def _z(alpha: float) -> float:
+    """Two-sided normal critical value (stdlib inverse-normal, no scipy)."""
+    return statistics.NormalDist().inv_cdf(1.0 - alpha / 2.0)
+
+
+def wilson_interval(k: int, n: int, alpha: float = 0.05) -> tuple[float, float]:
+    """Wilson score interval for a binomial proportion k/n. Closed-form."""
+    if n <= 0:
+        return (0.0, 1.0)
+    k = max(0, min(int(k), int(n)))
+    z = _z(alpha)
+    p = k / n
+    denom = 1.0 + z * z / n
+    center = (p + z * z / (2 * n)) / denom
+    half = (z * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n))) / denom
+    return (max(0.0, center - half), min(1.0, center + half))
+
+
+def clopper_pearson(k: int, n: int, alpha: float = 0.05) -> tuple[float, float]:
+    """Exact (Clopper-Pearson) binomial CI for a proportion k/n.
+
+    Uses the Beta-quantile form via scipy when available; otherwise falls back to
+    the Wilson score interval (close, and dependency-free).
+    """
+    if n <= 0:
+        return (0.0, 1.0)
+    k = max(0, min(int(k), int(n)))
+    try:
+        from scipy.stats import beta  # type: ignore
+    except Exception:
+        return wilson_interval(k, n, alpha)
+    lower = 0.0 if k == 0 else float(beta.ppf(alpha / 2.0, k, n - k + 1))
+    upper = 1.0 if k == n else float(beta.ppf(1.0 - alpha / 2.0, k + 1, n - k))
+    return (lower, upper)
+
+
+def bootstrap_ci(
+    statistic_fn: Callable[[np.ndarray], float],
+    n: int,
+    *,
+    n_boot: int = 1000,
+    alpha: float = 0.05,
+    seed: int = 0,
+) -> tuple[float, float, float]:
+    """Percentile bootstrap CI for a statistic computed over case indices.
+
+    ``statistic_fn`` maps an array of resampled row indices to a scalar (so it
+    works for paired data like AUROC over (y_true, y_score)). Returns
+    ``(point_estimate, ci_low, ci_high)``; NaN bootstrap draws (e.g. a resample
+    with a single class) are dropped before taking percentiles.
+    """
+    if n <= 0:
+        return (float("nan"), float("nan"), float("nan"))
+    point = float(statistic_fn(np.arange(n)))
+    rng = np.random.default_rng(seed)
+    draws: list[float] = []
+    for _ in range(n_boot):
+        idx = rng.integers(0, n, size=n)
+        val = statistic_fn(idx)
+        if val == val:  # not NaN
+            draws.append(float(val))
+    if len(draws) < max(20, n_boot // 10):
+        return (point, float("nan"), float("nan"))
+    lo = float(np.percentile(draws, 100 * alpha / 2.0))
+    hi = float(np.percentile(draws, 100 * (1.0 - alpha / 2.0)))
+    return (point, lo, hi)

--- a/backend/ml_engine/registry/gates.py
+++ b/backend/ml_engine/registry/gates.py
@@ -52,6 +52,10 @@ def check_gates(report: EvalReport, gate_cfg: EvalGates | None = None) -> GateRe
     # Triage detection — safety critical.
     require_min("triage.sensitivity", g.triage_sensitivity_min, "triage_sensitivity")
     require_min("triage.auroc", g.triage_auroc_min, "triage_auroc")
+    # Regulator-grade: optionally gate on the sensitivity lower confidence bound.
+    if getattr(g, "triage_sensitivity_ci_lower_min", 0.0) > 0:
+        require_min("triage.sensitivity_ci_low", g.triage_sensitivity_ci_lower_min,
+                    "triage_sensitivity_ci_low")
     # Report clinical efficacy.
     require_min("report.radgraph_f1", g.radgraph_f1_min, "radgraph_f1")
     require_min("report.chexbert_f1", g.chexbert_f1_min, "chexbert_f1")

--- a/backend/ml_engine/tests/test_models_smoke.py
+++ b/backend/ml_engine/tests/test_models_smoke.py
@@ -36,6 +36,26 @@ def test_masked_ssl_loss_is_scalar():
     assert loss.ndim == 0 and torch.isfinite(loss)
 
 
+def test_masked_ssl_uses_input_masking_and_trains_mask_token():
+    """SimMIM fix: masking affects the forward pass and the mask token learns."""
+    cfg = _tiny_cfg()
+    enc = MRIEncoder3D(cfg)
+    x = torch.randn(2, 1, *cfg.img_size)
+    mask = torch.ones(2, cfg.num_patches)            # mask everything
+    mtok = torch.randn(1, 1, cfg.embed_dim)
+    plain = enc(x)["pooled"]
+    masked = enc(x, token_mask=mask, mask_token=mtok)["pooled"]
+    assert not torch.allclose(plain, masked)         # input masking is actually applied
+
+    ssl = MaskedVolumeSSL(MRIEncoder3D(cfg))
+    pv = cfg.patch_size[0] * cfg.patch_size[1] * cfg.patch_size[2] * cfg.in_channels
+    target = torch.randn(2, cfg.num_patches, pv)
+    loss = ssl(x, target)
+    loss.backward()
+    assert ssl.mask_token.grad is not None           # mask token is in the graph
+    assert ssl.mask_token.grad.abs().sum() > 0       # ...and receives real signal
+
+
 def test_mrclip_loss_and_zeroshot():
     cfg = _tiny_cfg()
     clip = MRCLIP(MRIEncoder3D(cfg), MRCLIPConfig(proj_dim=16, text_dim=24))

--- a/backend/ml_engine/tests/test_stats.py
+++ b/backend/ml_engine/tests/test_stats.py
@@ -1,0 +1,86 @@
+"""Tests for evaluation statistical rigor (CIs) and the optional CI gate."""
+import numpy as np
+
+from ml_engine.evaluation import stats
+from ml_engine.evaluation.harness import EvalConfig, EvalHarness
+from ml_engine.registry.gates import check_gates
+from ml_engine.registry.models import EvalReport
+from ml_engine.config import EvalGates
+
+
+# --------------------------------------------------------------------------- #
+# Proportion CIs
+# --------------------------------------------------------------------------- #
+def test_clopper_pearson_brackets_point_and_edges():
+    lo, hi = stats.clopper_pearson(50, 100)
+    assert 0.0 <= lo < 0.5 < hi <= 1.0
+    assert 0.35 < lo < 0.41 and 0.59 < hi < 0.65        # known ~ (0.398, 0.602)
+    assert stats.clopper_pearson(10, 10)[1] == 1.0      # all successes -> upper 1
+    assert stats.clopper_pearson(0, 10)[0] == 0.0       # no successes -> lower 0
+    assert stats.clopper_pearson(5, 0) == (0.0, 1.0)    # n=0 -> uninformative
+
+
+def test_wilson_interval_sane():
+    lo, hi = stats.wilson_interval(8, 10)
+    assert 0.0 <= lo < 0.8 < hi <= 1.0
+    assert stats.wilson_interval(0, 0) == (0.0, 1.0)
+
+
+# --------------------------------------------------------------------------- #
+# Bootstrap
+# --------------------------------------------------------------------------- #
+def test_bootstrap_ci_brackets_and_deterministic():
+    data = np.array([0, 1] * 50, dtype=float)           # true mean 0.5
+    stat = lambda idx: float(data[idx].mean())
+    point, lo, hi = stats.bootstrap_ci(stat, len(data), n_boot=500, seed=0)
+    assert abs(point - 0.5) < 1e-9
+    assert lo < point < hi and 0.3 < lo and hi < 0.7
+    # deterministic for a fixed seed
+    again = stats.bootstrap_ci(stat, len(data), n_boot=500, seed=0)
+    assert (point, lo, hi) == again
+
+
+# --------------------------------------------------------------------------- #
+# Harness integration: CIs appear and bracket the point estimates
+# --------------------------------------------------------------------------- #
+def _triage_samples():
+    samples = []
+    for i in range(40):
+        pos = i % 2 == 0
+        samples.append({"study_id": f"S{i}",
+                        "triage": {"y_true": 1 if pos else 0,
+                                   "y_score": 0.9 if pos else 0.1}})
+    return samples
+
+
+def test_harness_reports_confidence_intervals():
+    report = EvalHarness(EvalConfig(bootstrap_n=200)).evaluate(_triage_samples(), test_set="t")
+    m = report.metrics
+    for key in ("triage.sensitivity_ci_low", "triage.sensitivity_ci_high",
+                "triage.auroc_ci_low", "triage.auroc_ci_high",
+                "triage.n", "triage.n_positive"):
+        assert key in m
+    assert m["triage.sensitivity_ci_low"] <= m["triage.sensitivity"] <= m["triage.sensitivity_ci_high"]
+    assert m["triage.auroc_ci_low"] <= m["triage.auroc"] <= m["triage.auroc_ci_high"]
+    assert m["triage.n"] == 40.0 and m["triage.n_positive"] == 20.0
+
+
+# --------------------------------------------------------------------------- #
+# Optional CI gate
+# --------------------------------------------------------------------------- #
+def _passing_metrics():
+    return {"triage.sensitivity": 0.96, "triage.auroc": 0.90,
+            "report.radgraph_f1": 0.5, "report.chexbert_f1": 0.6,
+            "calibration.ece": 0.05, "triage.sensitivity_ci_low": 0.80}
+
+
+def test_ci_gate_is_opt_in():
+    lenient = dict(radgraph_f1_min=0.0, chexbert_f1_min=0.0, triage_sensitivity_min=0.9,
+                   triage_auroc_min=0.8, ece_max=1.0, fairness_max_gap=1.0)
+    report = EvalReport(metrics=_passing_metrics())
+    # default (CI gate disabled) -> passes
+    assert check_gates(report, EvalGates(**lenient)).passed
+    # enable a strict CI lower-bound gate -> the 0.80 lower bound now fails it
+    strict = check_gates(report, EvalGates(**lenient, triage_sensitivity_ci_lower_min=0.99))
+    assert not strict.passed
+    assert any("ci_low" in f for f in strict.failures)

--- a/docs/aman-ai-world-class-roadmap.md
+++ b/docs/aman-ai-world-class-roadmap.md
@@ -1,0 +1,240 @@
+# Aman AI — Roadmap to a World-Class Brain-MRI AI Engine
+
+*Status: 2026-06-23. Owner: ML Engineering (Epic SCRUM-7). Audience: leadership (business) + technical leads.*
+
+This document is grounded in (a) a code audit of the current engine across ML,
+MLOps, and product layers, and (b) a verified deep-research pass on the 2024-2026
+state of the art (fact-checked by multi-vote adversarial verification; sources
+cited inline). It states honestly where we are, defines what "world-class" means
+in 2026, and gives a prioritized, evidence-backed plan with target metrics.
+
+---
+
+## 1. Executive summary (for leadership)
+
+**What we have.** A clean, end-to-end, *honestly-engineered* MRI AI engine: a 3D
+vision encoder, image-text alignment, an LLM report generator, a calibrated
+triage classifier, a full MLOps spine (model registry, lifecycle gates, audit
+log, drift monitor), a serving API, and a product flow wired into the existing
+radiologist worklist with mandatory sign-off. It runs on real GPUs (2x A10),
+trains on real open brain MRI (IXI), and is unit-tested. The safety posture
+(radiologist-in-the-loop, calibration, abstention, synthetic-data isolation) is
+genuinely strong and is our most defensible asset.
+
+**The honest gap.** Today the engine is **world-class infrastructure wrapped
+around prototype-grade models**. Three things separate us from a fundable,
+publishable, certifiable product:
+1. **Data.** We train on synthetic/open data with **no paired radiology
+   reports**. The entire SOTA in this field is built on *report-paired 3D scans*
+   (e.g. CT-RATE: 25,692 chest CT each with a report). This is the single
+   highest-leverage gap. [arXiv:2403.17834]
+2. **Model recipes.** Our architectures are sound but generic (2021-era MAE/CLIP),
+   not the 2025-26 medical recipes (foundation-model warm-starts, grounded
+   reporting, factuality-rewarded generation).
+3. **Evaluation credibility.** Several "clinical" metrics are home-grown
+   approximations, and we report point estimates with **no confidence intervals**
+   — below the bar a journal reviewer or regulator will accept.
+
+**The opportunity.** Brain-MRI report generation is *under-served* versus chest
+imaging, and pixel-grounded brain-MRI reporting is brand-new (first method
+published mid-2024). With the right data partnership and the upgrades below, this
+is a credible path to (a) a strong arXiv/MICCAI publication, (b) defensible IP,
+and (c) an assistive SaMD product on the EU/US/KZ regulatory lanes.
+
+**The ask.** (1) Secure one **report-paired brain-MRI data partnership** (the
+critical path). (2) Fund a ~6-month ML push to SOTA recipes + a credible
+evaluation. (3) In parallel we are already shipping the engineering quick-wins
+(this session) that make the platform safe and reproducible.
+
+---
+
+## 2. Where we are — honest audit
+
+### Genuinely strong (defensible today)
+- **MLOps lifecycle**: explicit state machine, immutable versions, append-only
+  audit log, reader-study sign-off + model lock before production, gates that
+  treat a missing metric as a failure (correct safety default).
+- **Calibration & triage safety**: correct Guo-2017 temperature scaling, ECE/MCE/
+  Brier, abstention band; drift via PSI + two-sample KS; tie-corrected AUROC.
+- **Safety-by-design**: assistive-only, radiologist signs every report; synthetic
+  augmentation is provably isolated from patient-facing views (enforced invariant).
+- **Product spine**: real auth/RBAC, patient-scoped authorization, a working
+  worklist -> review -> sign-off workflow with an audit trail.
+
+### Gaps that block "world-class" (with fixes in section 4)
+- **ML (models):** the masked-autoencoder objective is mis-implemented (encodes
+  the full volume, masks *after* the forward pass); alignment has no real text
+  encoder; the triage head trains on synthetic linearly-separable features (so its
+  reported AUROC/sensitivity are self-fulfilling); report-gen has no grounding,
+  no structured findings, and no factuality objective despite docstring claims.
+- **Evaluation:** BLEU/ROUGE/METEOR are hand-rolled and diverge from standard
+  implementations; **RadGraph and CheXbert are not actually run** (they are
+  set/dict overlap over labels the generator itself emits); GREEN is a stub. No
+  bootstrap confidence intervals, Clopper-Pearson bounds, or significance tests
+  anywhere. No experiment tracking (MLflow is commented out); the eval harness
+  sets no seed and never records the git SHA.
+- **Product:** the inference FastAPI endpoint has **no authentication**; sign-off
+  is non-atomic (no DB transaction / optimistic lock); slow ML inference runs
+  synchronously and will time out on real volumes; the worklist silently shows
+  **mock data on a DB error** (a radiologist could see fabricated findings);
+  `mapRisk` never returns CRITICAL; secrets are committed; there is no CI/CD.
+
+---
+
+## 3. What "world-class" means in 2026 (verified research)
+
+**The data lever dominates.** The proven path is *report-paired 3D volumes*.
+CT-RATE (25,692 chest CT / 21,304 patients, each with a report) is the template;
+CT-CHAT pairs that encoder with an LLM over 2.7M+ QA pairs — the same
+encoder->projector->LLM shape we already have. IXI has **no reports**, so
+report-paired MRI must be acquired. [arXiv:2403.17834; Nature BME s41551-025-01599-y]
+
+**Brain-MRI foundation models exist — and they favor contrastive SSL.**
+BrainIAC (Nature Neuroscience 2026) is a 3D ViT-B trained with **contrastive
+SimCLR**, explicitly chosen over MAE and over ResNet/Swin baselines, on 32,015
+multiparametric MRIs from 16 datasets. In low-data regimes it crushes prior
+backbones (10% data: balanced-acc 90.8 vs 74.2). Implication: our MAE-only
+encoder default is not the 2026 recipe for brain MRI; add a contrastive objective
+and warm-start from a public brain-MRI FM. [Nature Neuro s41593-026-02202-6; arXiv:2412.17041]
+
+**Reporting is now grounded.** MAIRA-2 set the grounded-reporting paradigm
+(frozen Rad-DINO ViT -> MLP adapter -> 7B LLM, reports as sentences with spatial
+boxes). AutoRG-Brain is the first **pixel-grounded brain-MRI** report generator
+(anomaly-ROI segmentation then visual prompting), reporting Prompt RadGraph 41.74
+/ RadCliQ 0.30 / RaTEScore 68.76 (oracle-mask setting) vs MedFlamingo 16.93.
+Grounding + structured findings is the differentiator for trust. [arXiv:2406.04449; arXiv:2407.16684]
+
+**Factuality is trained, not hoped for.** Evidence-aware RL rewards that score
+true/false-positive/false-negative findings against spatial maps improve clinical
+metrics over supervised fine-tuning (e.g. RadGraph-F1 +~0.02-0.03 in CXR
+studies). The lever is real; specific numbers are CXR-2D and not universal
+targets. [arXiv:2604.13598, medium confidence]
+
+**Evaluation the field trusts:** RadGraph-F1, GREEN (LLM-based factuality),
+RadCliQ, RaTEScore for reports; sensitivity-at-fixed-specificity, AUROC, ECE, and
+OOD/abstention for triage; subgroup/fairness breakdowns; and — non-negotiable for
+publication/regulators — **confidence intervals (bootstrap; Clopper-Pearson for
+sensitivity)**, frozen hash-pinned test sets, model cards, data statements, seeds,
+and ablations.
+
+> Note: some widely-repeated claims did **not** survive verification and are *not*
+> used here as targets (e.g. "CT-CLIP beats supervised on all metrics", a specific
+> "MedGemma SOTA RadGraph-F1 30.3", and treating one paper's CXR numbers as
+> universal 2026 targets). We anchor to *paradigms and method levers*, not to
+> contested leaderboard numbers.
+
+---
+
+## 4. The plan — three senior lenses
+
+### 4A. ML / Research (primary focus)
+
+**Encoder (Stage A)**
+- *Now (quick-win):* fix the SSL objective to true masked-input prediction
+  (SimMIM-style: corrupt masked patches at the input with a learnable mask token,
+  reconstruct masked patches only, normalize patch targets). [shipping this session]
+- *Next:* add a **SimCLR/SigLIP contrastive SSL** option (BrainIAC-aligned) and
+  support **warm-starts from a public brain-MRI FM**; move to a hierarchical /
+  multi-scale 3D backbone for small-lesion sensitivity.
+- *Multi-modal routing:* actually implement T1/T2/FLAIR/SWI fusion (config lists
+  it; code is single-channel).
+
+**Alignment (Stage B)**
+- Wire a real **frozen biomedical text encoder** (BiomedCLIP / CXR-BERT-style)
+  instead of the current placeholder linear-over-precomputed-vector.
+- Swap InfoNCE -> **SigLIP** loss (better at small batch), add **hard-negative
+  mining** and **local+global** (token-level) alignment for localized findings.
+
+**Report generation (Stage C)**
+- Add **grounding** (segmentation-anchored, AutoRG-Brain style) and actually emit
+  the `StructuredFinding` objects that are defined but never produced.
+- Add a **factuality objective** (RadGraph/entity-F1 or GREEN-style reward; DPO/RL)
+  on top of next-token loss; constrain decoding to the clinical vocabulary;
+  implement the promised **abstention**.
+
+**Triage (Stage D)**
+- *Now (quick-win):* **focal loss + class weighting** for rare critical findings,
+  **per-class temperature**, and **operating-point selection at a target
+  sensitivity** instead of a hard-coded abstention band.
+- *Next:* **conformal / risk-controlled prediction** to give a statistical
+  guarantee on critical-finding sensitivity — a genuine safety differentiator.
+
+**Augmentation (Stage E)**
+- Wire a real generative backend (currently `NotImplementedError`) with FID/expert
+  quality-gating and a principled real:synthetic mixing policy; keep the
+  (excellent) isolation invariant.
+
+**Publication / IP angle.** Two credible thrusts: (1) *pixel-grounded brain-MRI
+reporting with risk-controlled triage* (novel; brain MRI is under-served) — target
+a MICCAI / Radiology: AI submission; (2) defensible IP around the
+**provably-isolated synthetic-augmentation safety invariant** and the
+**conformal critical-finding guarantee**.
+
+### 4B. Evaluation & MLOps (the credibility layer)
+- *Now (quick-wins):* real NLG metrics (`sacrebleu`, `rouge-score`); **bootstrap
+  CIs + Clopper-Pearson** lower bound on sensitivity, and **gate on the CI lower
+  bound**; fix the RadGraph empty-set F1=1.0 bug; fix the `subgroup_metrics` type
+  contract; record seed + git SHA + full (untruncated) test-set hash; add MLflow
+  experiment tracking. [several shipping this session]
+- *Next:* integrate **real RadGraph / f1chexbert / GREEN**, validated against
+  published numbers; build a **frozen, hash-verified multi-site test set** with a
+  data card; stand up a **reader-study / MRMC** harness feeding the existing
+  sign-off; surface calibration reliability tables into the model card.
+
+### 4C. Product / Fullstack (make it safe and scalable)
+- *Now (urgent safety quick-wins):* add **auth on the inference endpoint**; make
+  **sign-off atomic** (transaction + "already signed" guard + optimistic lock);
+  stop showing **mock data on DB error** in the worklist; fix `mapRisk` CRITICAL;
+  move **secrets to a vault**; add a **CI workflow** (lint + typecheck + tests +
+  build).
+- *Next:* **async inference** (persist `Analysis(PENDING)`, enqueue to a
+  Redis/Celery worker on the GPU host, return 202, poll/stream status);
+  **observability** (structured logs, OpenTelemetry traces, Prometheus latency/
+  error metrics); **PHI hardening** (encryption at rest, signed-URL object storage
+  with read audit, retention); a **typed OpenAPI contract** between Next and FastAPI.
+
+---
+
+## 5. Target metrics — what lets leadership credibly say "world-class"
+
+| Dimension | Today | World-class target (2026 anchor) |
+|---|---|---|
+| Report factuality | RadGraph/CheXbert **approximated** (not real) | Real **RadGraph-F1** + **GREEN** + **RadCliQ/RaTEScore**, reported with 95% CIs; competitive with AutoRG-Brain-class brain-MRI reporting [arXiv:2407.16684] |
+| Critical-finding triage | sensitivity on **synthetic** task | **Sensitivity >= 0.95 with a Clopper-Pearson lower bound**, AUROC, ECE <= 0.05, OOD-abstention, **conformal guarantee** |
+| Foundation | MAE on IXI (no reports) | Contrastive SSL warm-started from a **brain-MRI FM**, trained on **report-paired** data [Nature Neuro s41593-026-02202-6] |
+| Reproducibility | no tracking, no seed, no CI | **MLflow** run lineage, seeds, git SHA, **frozen hash-pinned test set**, model cards, ablations |
+| Clinical validation | sign-off boolean | **Reader study / MRMC** with inter-rater agreement |
+| Product reliability | sync inference, no CI, safety bugs | async job pipeline, observability, CI/CD, **zero patient-safety defects** |
+
+---
+
+## 6. Sequencing
+
+- **This week (engineering quick-wins, in progress this session):** SSL MAE fix;
+  triage focal-loss + per-class temperature + operating point; bootstrap CIs +
+  CI-gated sensitivity; real NLG metrics + metric-honesty fixes; MLflow tracking;
+  reproducibility metadata; urgent product-safety fixes; first CI workflow.
+- **30-60-90 days:** real RadGraph/CheXbert/GREEN; biomedical text encoder +
+  SigLIP alignment; report-gen grounding + structured findings; async inference +
+  observability; frozen multi-site test set + data card.
+- **6-12 months (needs the data partnership):** train on report-paired brain MRI
+  warm-started from a brain-MRI FM; factuality RL; conformal triage; reader study;
+  regulatory pack (EU MDR + EU AI Act high-risk obligations are phasing in through
+  2026; assistive radiology AI is high-risk) and KZ registration.
+
+---
+
+## 7. Risks & honest caveats
+- **Data licensing is the critical path** (decision D10): research datasets
+  (MR-RATE etc.) are non-commercial; the production model needs commercially
+  cleared, report-paired partner data. No amount of engineering substitutes for this.
+- **Do not overclaim.** Until the real metrics + reader study exist, this is
+  "validated engineering on research-licensed data", not a certified device.
+- **Regulatory timeline is long and multi-party** (months), independent of code.
+
+---
+
+## 8. Implemented in this session
+See the accompanying PR(s). This session delivers the first batch of section-4
+quick-wins (ML SSL correctness + evaluation statistical rigor), each unit-tested,
+plus this roadmap. Subsequent batches follow the sequencing in section 6.


### PR DESCRIPTION
First batch of the "world-class" push (ML/Research focus), with a research-grounded roadmap. Each change is unit-tested; full `ml_engine` suite: **51 passed, 1 skipped** (skip = pre-existing offline report-gen test).

## 1. SSL correctness — true SimMIM input masking (SCRUM-21)
The masked-volume objective encoded the **full** volume and applied the mask **after** the forward pass — the reconstruction target was decoupled from what the encoder saw, so it produced no transferable self-supervised signal (a real correctness bug). Now masked patches are replaced at the **input** with a learnable mask token before encoding, and the loss is computed on the masked patches only against per-patch-normalised targets — the standard SimMIM/MAE recipe. `MRIEncoder3D.forward` gains optional `(token_mask, mask_token)` kwargs (backward compatible). New test asserts masking actually changes the forward pass and the mask token receives gradient.

## 2. Evaluation statistical rigor — confidence intervals (SCRUM-26)
Point estimates without uncertainty are below the journal/regulator bar. Adds `evaluation/stats.py`:
- **Clopper-Pearson** exact binomial CI (Wilson fallback, no hard scipy dependency) for proportions.
- **Percentile bootstrap** CI for any statistic (used for AUROC).

The harness now reports, on every eval: `triage.sensitivity_ci_low/high` (Clopper-Pearson), `triage.auroc_ci_low/high` (bootstrap), and `triage.n / n_positive`. Adds an **opt-in** promotion gate on the sensitivity **lower confidence bound** (`AMAN_ML_GATE_TRIAGE_SENS_CI_LOW`, default `0.0` = disabled, so existing flows are unchanged). This is what lets us gate on "sensitivity >= 0.95 *with* a CI lower bound", which regulators expect.

## 3. Roadmap document (`docs/aman-ai-world-class-roadmap.md`)
Dual-audience (leadership + technical) plan, grounded in a verified deep-research pass (fact-checked by multi-vote verification; sources cited). Honest audit (strengths + the three gaps: data, model recipes, evaluation credibility), what "world-class" means in 2026 (report-paired 3D data is the dominant lever; brain-MRI FMs favour contrastive SSL; grounded reporting; factuality RL), target metrics, and a quick-wins -> 90-day -> 6-12-month sequencing across ML / MLOps / product.

## Why this batch first
These are the highest-leverage, lowest-risk, ML/research-core items from the audit: a genuine correctness fix and the evaluation-credibility layer. They are additive and safe.

## Next batches (tracked in the roadmap, not in this PR)
- ML: real biomedical text encoder + SigLIP alignment; report-gen grounding + structured findings + factuality reward; triage focal-loss + per-class temperature + conformal abstention; brain-MRI FM warm-start.
- MLOps: real RadGraph/CheXbert/GREEN; MLflow tracking; frozen hash-pinned test set; reader-study/MRMC harness.
- Product (urgent safety, separate PR): backend inference auth; atomic sign-off; stop showing mock data on DB error; async inference; CI/CD; secret management.