### PR TITLE
SCRUM-64: guard MIMIC/PhysioNet EHR data from the repo (Phase 0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,14 @@ nul
 
 # Graphify (codebase knowledge graph) — regenerated locally / via post-commit hook
 graphify-out/
+
+# MIMIC / PhysioNet EHR data — R&D only (ODbL demo or credentialed full set).
+# NEVER commit a single row. Data lives on a controlled machine OUTSIDE this repo
+# (see docs/mimic-data-strategy.md, SCRUM-64). These patterns are a defensive guard.
+mimic-iv-demo/
+mimic-iv/
+mimic-*/
+**/mimic-*/
+physionet-data/
+**/physionet-data/
+data/mimic*/


### PR DESCRIPTION
Part of **SCRUM-64 — MIMIC Phase 0 gate**. Closes the "controlled storage + .gitignore" item.

## What
Adds a defensive `.gitignore` block for MIMIC / PhysioNet EHR data paths
(`mimic-*/`, `**/mimic-*/`, `physionet-data/`, `data/mimic*/`).

## Why
Per `docs/mimic-data-strategy.md` (PR #29) guardrails: MIMIC is R&D / pretrain / eval
only and **must never be committed**. The actual data lives on a controlled machine
**outside** the repo; this is a belt-and-suspenders guard so no MIMIC row can be staged
from inside the working tree.

## Phase 0 gate status
- [x] **Legal / owner sign-off** — Alnur approved R&D-only use (2026-06-30); derived
      models stay `license_cleared=False`, never promoted to PRODUCTION.
- [x] **ODbL demo downloaded** — MIMIC-IV Clinical Database Demo v2.2 (~100 patients,
      ODbL, no DUA) fetched to a controlled dir outside the repo; all 34 files verified
      against the official `SHA256SUMS` (34/34 OK). Provenance recorded in
      `DATA_PROVENANCE.md` alongside the data.
- [x] **Controlled storage + .gitignore** — this PR. Data confirmed outside the repo
      tree; ignore rules verified with `git check-ignore`.

Gate closed → unblocks SCRUM-65 (EHR ingestion adapter). No data files are added by this PR.