### PR TITLE
SCRUM-68: S2 biosignal encoder — MIMIC ICU-vitals ingestion + SSL pretraining

### DIFF
--- a/backend/ml_engine/__init__.py
+++ b/backend/ml_engine/__init__.py
@@ -13,6 +13,7 @@ Sub-packages
 - ``report_gen``  SCRUM-23  LLM + LoRA report generator
 - ``triage_head`` SCRUM-24  calibrated triage classifier
 - ``augmentation``SCRUM-25  NV-Generate-MR-Brain synthetic augmentation
+- ``biosignal``   SCRUM-68  S2 biosignal encoder (SSL on MIMIC ICU vitals)
 
 Reference: SRS/ТЗ §7 (ML / AI Pipeline), Phases P1-P2.
 """

--- a/backend/ml_engine/biosignal/__init__.py
+++ b/backend/ml_engine/biosignal/__init__.py
@@ -1,0 +1,10 @@
+"""SCRUM-68 — S2 biosignal encoder: SSL pretraining on MIMIC ICU vitals.
+
+Importing this package requires PyTorch (a training-time dependency), same as
+``ml_engine.encoder``. See ``ml_engine/requirements.txt``.
+"""
+from .model import BiosignalEncoder1D, BiosignalEncoderConfig, MaskedBiosignalSSL, patchify_1d
+
+__all__ = [
+    "BiosignalEncoder1D", "BiosignalEncoderConfig", "MaskedBiosignalSSL", "patchify_1d",
+]

--- a/backend/ml_engine/biosignal/model.py
+++ b/backend/ml_engine/biosignal/model.py
@@ -1,0 +1,151 @@
+"""1D biosignal encoder + masked-timestep SSL objective (SCRUM-68, MIMIC Phase 3).
+
+Applies the 3D MRI encoder's proven SimMIM-style recipe (see
+:mod:`ml_engine.encoder`, decision D15 — input-masking beats masking after the
+forward pass) to short multichannel ICU-vitals windows (heart rate,
+respiratory rate, SpO2, NIBP systolic/diastolic — see
+:mod:`ml_engine.ingestion.ehr`). This is a pretraining scaffold for the S2
+service's eventual wearable-PPG/ECG encoder (team Mukhammedzhan), not a
+finished HRV model — see ``ingestion.ehr``'s docstring for the data-tier gap
+(charted vitals now, continuous waveforms only after credentialed MIMIC
+Waveform DB / MIMIC-IV-ECG access).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+
+
+@dataclass
+class BiosignalEncoderConfig:
+    in_channels: int = 5                  # see ingestion.ehr.VITAL_ITEMS order
+    seq_len: int = 24                     # hourly steps per window
+    patch_size: int = 4                   # timesteps per token
+    embed_dim: int = 128
+    depth: int = 4
+    num_heads: int = 4
+    mlp_ratio: float = 4.0
+    mask_ratio: float = 0.5
+    drop: float = 0.0
+    channels: tuple[str, ...] = (
+        "heart_rate", "resp_rate", "spo2", "nibp_systolic", "nibp_diastolic",
+    )
+
+    @property
+    def num_patches(self) -> int:
+        return self.seq_len // self.patch_size
+
+
+def patchify_1d(x: torch.Tensor, patch_size: int) -> torch.Tensor:
+    """``(B, C, T)`` -> ``(B, N, C*patch_size)`` in token order matching
+    :class:`PatchEmbed1D`'s ``Conv1d`` output, so reconstruction targets line
+    up with the encoder's patch tokens."""
+    b, c, t = x.shape
+    n = t // patch_size
+    xr = x[:, :, : n * patch_size].reshape(b, c, n, patch_size)
+    xr = xr.permute(0, 2, 1, 3).contiguous()
+    return xr.reshape(b, n, c * patch_size)
+
+
+class PatchEmbed1D(nn.Module):
+    def __init__(self, cfg: BiosignalEncoderConfig):
+        super().__init__()
+        self.proj = nn.Conv1d(cfg.in_channels, cfg.embed_dim,
+                              kernel_size=cfg.patch_size, stride=cfg.patch_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (B, C, T) -> (B, N, embed_dim)
+        x = self.proj(x)
+        return x.transpose(1, 2)
+
+
+class BiosignalEncoder1D(nn.Module):
+    """Transformer encoder over patch-embedded multichannel vitals windows."""
+
+    def __init__(self, cfg: BiosignalEncoderConfig | None = None):
+        super().__init__()
+        self.cfg = cfg or BiosignalEncoderConfig()
+        self.patch_embed = PatchEmbed1D(self.cfg)
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, self.cfg.embed_dim))
+        self.pos_embed = nn.Parameter(torch.zeros(1, self.cfg.num_patches + 1, self.cfg.embed_dim))
+        layer = nn.TransformerEncoderLayer(
+            d_model=self.cfg.embed_dim, nhead=self.cfg.num_heads,
+            dim_feedforward=int(self.cfg.embed_dim * self.cfg.mlp_ratio),
+            dropout=self.cfg.drop, batch_first=True, activation="gelu",
+        )
+        self.blocks = nn.TransformerEncoder(layer, num_layers=self.cfg.depth)
+        self.norm = nn.LayerNorm(self.cfg.embed_dim)
+        nn.init.trunc_normal_(self.pos_embed, std=0.02)
+        nn.init.trunc_normal_(self.cls_token, std=0.02)
+
+    @property
+    def embed_dim(self) -> int:
+        return self.cfg.embed_dim
+
+    def forward(self, x: torch.Tensor, *, token_mask: torch.Tensor | None = None,
+                mask_token: torch.Tensor | None = None) -> dict[str, torch.Tensor]:
+        tokens = self.patch_embed(x)
+        if token_mask is not None and mask_token is not None:
+            # SimMIM-style input masking (see ml_engine.encoder.MaskedVolumeSSL
+            # / decision D15): replace masked patch embeddings with a shared
+            # learnable mask token *before* encoding. token_mask: (B, N), 1=masked.
+            w = token_mask.unsqueeze(-1).to(tokens.dtype)
+            tokens = tokens * (1.0 - w) + mask_token.to(tokens.dtype) * w
+        cls = self.cls_token.expand(tokens.size(0), -1, -1)
+        tokens = torch.cat([cls, tokens], dim=1) + self.pos_embed[:, : tokens.size(1) + 1]
+        tokens = self.norm(self.blocks(tokens))
+        return {"patch_tokens": tokens[:, 1:], "pooled": tokens[:, 0]}
+
+    def encode(self, x: torch.Tensor) -> torch.Tensor:
+        """Pooled window-level embedding (for downstream probes)."""
+        return self.forward(x)["pooled"]
+
+    def load_pretrained(self, ckpt_path: str, *, strict: bool = False) -> list[str]:
+        state = torch.load(ckpt_path, map_location="cpu")
+        state = state.get("model", state)
+        result = self.load_state_dict(state, strict=strict)
+        return list(result.missing_keys) + list(result.unexpected_keys)
+
+
+class MaskedBiosignalSSL(nn.Module):
+    """SimMIM-style masked-timestep reconstruction head (mirrors
+    :class:`ml_engine.encoder.MaskedVolumeSSL`, decision D15): masked patches
+    are replaced at the input with a learnable mask token, and the loss is
+    computed on the masked patches only against per-patch-normalised targets.
+    """
+
+    def __init__(self, encoder: BiosignalEncoder1D):
+        super().__init__()
+        self.encoder = encoder
+        cfg = encoder.cfg
+        patch_values = cfg.patch_size * cfg.in_channels
+        self.mask_token = nn.Parameter(torch.zeros(1, 1, cfg.embed_dim))
+        nn.init.trunc_normal_(self.mask_token, std=0.02)
+        self.decoder = nn.Sequential(
+            nn.Linear(cfg.embed_dim, cfg.embed_dim), nn.GELU(),
+            nn.Linear(cfg.embed_dim, patch_values),
+        )
+
+    def random_mask(self, n_patches: int, batch: int, device) -> torch.Tensor:
+        keep = max(1, int(n_patches * (1 - self.encoder.cfg.mask_ratio)))
+        noise = torch.rand(batch, n_patches, device=device)
+        ids = torch.argsort(noise, dim=1)
+        mask = torch.ones(batch, n_patches, device=device)
+        mask.scatter_(1, ids[:, :keep], 0)  # 0 = visible, 1 = masked
+        return mask
+
+    @staticmethod
+    def _normalize_patches(target: torch.Tensor) -> torch.Tensor:
+        mu = target.mean(dim=-1, keepdim=True)
+        var = target.var(dim=-1, keepdim=True, unbiased=False)
+        return (target - mu) / (var + 1e-6).sqrt()
+
+    def forward(self, x: torch.Tensor, target_patches: torch.Tensor) -> torch.Tensor:
+        mask = self.random_mask(self.encoder.cfg.num_patches, x.size(0), x.device)
+        out = self.encoder(x, token_mask=mask, mask_token=self.mask_token)
+        pred = self.decoder(out["patch_tokens"])
+        target = self._normalize_patches(target_patches)
+        loss = ((pred - target) ** 2).mean(dim=-1)             # (B, N)
+        return (loss * mask).sum() / mask.sum().clamp(min=1)   # masked patches only

--- a/backend/ml_engine/biosignal/train.py
+++ b/backend/ml_engine/biosignal/train.py
@@ -1,0 +1,277 @@
+"""SSL pretraining loop for the S2 biosignal encoder (SCRUM-68, MIMIC Phase 3).
+
+Drives :class:`ml_engine.biosignal.MaskedBiosignalSSL` through a
+masked-timestep reconstruction objective and versions the resulting
+checkpoint in the model registry (mirrors
+:mod:`ml_engine.encoder.train`'s Stage-A loop for the 3D MRI encoder).
+
+Scaffold caveats (deliberately explicit — do not mistake this for a clinically
+meaningful HRV model):
+  * Real data is MIMIC-IV *demo* ICU ``chartevents`` — hourly-resampled vitals
+    (HR, RR, SpO2, NIBP), **not** continuous PPG/ECG waveforms. See
+    :mod:`ml_engine.ingestion.ehr`'s docstring for what would be needed for
+    true HRV (credentialed MIMIC Waveform DB / MIMIC-IV-ECG).
+  * Every MIMIC-derived checkpoint registers with ``license_cleared=False``
+    and is never a production candidate (D10/D11,
+    ``docs/mimic-data-strategy.md`` §6).
+  * ``SyntheticVitalsWindows`` keeps the loop runnable without any data
+    download at all (e.g. CI); swap in ``--mimic-dir`` for the real demo data,
+    nothing else in the loop changes.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader, Dataset
+
+from .model import BiosignalEncoder1D, BiosignalEncoderConfig, MaskedBiosignalSSL, patchify_1d
+
+
+# --------------------------------------------------------------------------- #
+# Data
+# --------------------------------------------------------------------------- #
+class SyntheticVitalsWindows(Dataset):
+    """Placeholder cohort of smooth, per-channel vitals windows.
+
+    Stands in for real MIMIC ICU vitals so the training pipeline is runnable
+    without any data download. Each sample is ``(C, T)`` with smooth
+    low-frequency structure (so reconstruction is non-trivial), seeded
+    deterministically for reproducibility.
+    """
+
+    def __init__(self, cfg: BiosignalEncoderConfig, length: int = 256, seed: int = 0):
+        self.cfg = cfg
+        self.length = length
+        self.seed = seed
+
+    def __len__(self) -> int:
+        return self.length
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        g = torch.Generator().manual_seed(self.seed + idx)
+        t = self.cfg.seq_len
+        coarse = torch.randn(self.cfg.in_channels, max(1, t // 4), generator=g)
+        x = F.interpolate(coarse.unsqueeze(0), size=t, mode="linear",
+                          align_corners=False).squeeze(0)
+        return (x - x.mean(dim=-1, keepdim=True)) / (x.std(dim=-1, keepdim=True) + 1e-6)
+
+
+class EhrVitalsDataset(Dataset):
+    """Real MIMIC ICU-vitals windows (see :mod:`ml_engine.ingestion.ehr`)."""
+
+    def __init__(self, mimic_dir: str, cfg: BiosignalEncoderConfig, **load_kwargs: Any):
+        from ..ingestion.ehr import load_vitals_windows, normalise_windows
+        windows, manifests = load_vitals_windows(
+            mimic_dir, channels=cfg.channels, window_steps=cfg.seq_len, **load_kwargs,
+        )
+        self.windows = torch.from_numpy(normalise_windows(windows))
+        self.manifests = manifests
+        self.data_source = f"mimic-ehr:{mimic_dir} ({len(manifests)} stays)"
+
+    def __len__(self) -> int:
+        return len(self.windows)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        return self.windows[idx]
+
+
+# --------------------------------------------------------------------------- #
+# Schedule
+# --------------------------------------------------------------------------- #
+def cosine_warmup(step: int, *, warmup: int, total: int) -> float:
+    """LR multiplier: linear warmup then cosine decay to ~0."""
+    if step < warmup:
+        return (step + 1) / max(1, warmup)
+    progress = (step - warmup) / max(1, total - warmup)
+    return 0.5 * (1.0 + math.cos(math.pi * min(1.0, progress)))
+
+
+# --------------------------------------------------------------------------- #
+# Training
+# --------------------------------------------------------------------------- #
+def run_training(
+    cfg: BiosignalEncoderConfig,
+    *,
+    steps: int = 100,
+    batch_size: int = 8,
+    lr: float = 1.5e-4,
+    weight_decay: float = 0.05,
+    warmup: int = 10,
+    grad_clip: float = 1.0,
+    device: str = "cpu",
+    amp: bool = False,
+    dataset_len: int = 512,
+    log_every: int = 10,
+    out_dir: str | Path = "checkpoints",
+    version: str = "0.1.0",
+    name: str = "s2-biosignal-encoder",
+    register: bool = False,
+    code_commit: str = "",
+    mimic_dir: str | None = None,
+    dataset: Dataset | None = None,
+    seed: int = 0,
+) -> dict[str, Any]:
+    torch.manual_seed(seed)
+    dev = torch.device(device if (device != "cuda" or torch.cuda.is_available()) else "cpu")
+
+    encoder = BiosignalEncoder1D(cfg)
+    model = MaskedBiosignalSSL(encoder).to(dev)
+
+    if dataset is not None:
+        # Caller-supplied dataset (e.g. tests probing a specific cohort).
+        ds = dataset
+        data_source = getattr(dataset, "data_source", f"custom:{type(dataset).__name__}")
+    elif mimic_dir:
+        ds = EhrVitalsDataset(mimic_dir, cfg)
+        data_source = ds.data_source
+    else:
+        ds = SyntheticVitalsWindows(cfg, length=dataset_len, seed=seed)
+        data_source = "synthetic-placeholder"
+    loader = DataLoader(ds, batch_size=min(batch_size, len(ds)), shuffle=True, drop_last=True,
+                        num_workers=0)
+
+    opt = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay,
+                            betas=(0.9, 0.95))
+    sched = torch.optim.lr_scheduler.LambdaLR(
+        opt, lambda s: cosine_warmup(s, warmup=warmup, total=steps))
+    use_amp = amp and dev.type == "cuda"
+    scaler = torch.amp.GradScaler("cuda", enabled=use_amp)
+
+    model.train()
+    history: list[dict[str, float]] = []
+    step = 0
+    data_iter = iter(loader)
+    first_loss = last_loss = float("nan")
+    while step < steps:
+        try:
+            x = next(data_iter)
+        except StopIteration:
+            data_iter = iter(loader)
+            x = next(data_iter)
+        if isinstance(x, (list, tuple)):
+            x = x[0]
+        x = x.to(dev, non_blocking=True)
+        target = patchify_1d(x, cfg.patch_size).to(dev, non_blocking=True)
+
+        opt.zero_grad(set_to_none=True)
+        with torch.autocast(device_type=dev.type, enabled=use_amp):
+            loss = model(x, target)
+        scaler.scale(loss).backward()
+        scaler.unscale_(opt)
+        torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
+        scaler.step(opt)
+        scaler.update()
+        sched.step()
+
+        last_loss = float(loss.detach().cpu())
+        if step == 0:
+            first_loss = last_loss
+        if step % log_every == 0 or step == steps - 1:
+            rec = {"step": step, "loss": last_loss, "lr": sched.get_last_lr()[0]}
+            history.append(rec)
+            print(json.dumps(rec), flush=True)
+        step += 1
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ckpt_path = out_dir / f"{name}-{version}.pt"
+    torch.save({
+        "model": encoder.state_dict(),       # encoder-only -> load_pretrained compatible
+        "cfg": asdict(cfg),
+        "step": step,
+        "final_loss": last_loss,
+        "objective": "masked_biosignal_ssl",
+    }, ckpt_path)
+
+    summary: dict[str, Any] = {
+        "name": name,
+        "version": version,
+        "device": str(dev),
+        "amp": use_amp,
+        "steps": step,
+        "first_loss": first_loss,
+        "final_loss": last_loss,
+        "checkpoint": str(ckpt_path),
+        "params_M": round(sum(p.numel() for p in encoder.parameters()) / 1e6, 3),
+        "data": data_source,
+    }
+
+    if register:
+        # Lazy import: keeps torch-only training decoupled from the registry.
+        from ..registry import ModelRegistry
+        from ..registry.models import DataProvenance
+        reg = ModelRegistry()
+        card = reg.register(
+            name=name, version=version, stage="biosignal_encoder",
+            artifact_uri=str(ckpt_path.resolve()), code_commit=code_commit,
+            config={**asdict(cfg), "objective": "masked_biosignal_ssl",
+                    "steps": step, "final_loss": last_loss},
+            data=DataProvenance(
+                train_datasets=[data_source], dataset_hash="", license_cleared=False,
+                notes=("MIMIC-IV demo ICU vitals (or synthetic placeholder) — "
+                       "R&D only, never a production candidate (D10/D11)."),
+            ),
+        )
+        summary["registered"] = card.model_id
+
+    print(json.dumps({"summary": summary}, default=str), flush=True)
+    return summary
+
+
+def _build_cfg(args: argparse.Namespace) -> BiosignalEncoderConfig:
+    return BiosignalEncoderConfig(
+        seq_len=args.seq_len, patch_size=args.patch_size,
+        embed_dim=args.embed_dim, depth=args.depth, num_heads=args.heads,
+        mask_ratio=args.mask_ratio,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="ml_engine.biosignal.train",
+        description="SSL pretrain the S2 biosignal encoder on MIMIC ICU vitals (SCRUM-68)")
+    ap.add_argument("--steps", type=int, default=100)
+    ap.add_argument("--batch-size", type=int, default=8, dest="batch_size")
+    ap.add_argument("--seq-len", type=int, default=24, dest="seq_len")
+    ap.add_argument("--patch-size", type=int, default=4, dest="patch_size")
+    ap.add_argument("--embed-dim", type=int, default=128, dest="embed_dim")
+    ap.add_argument("--depth", type=int, default=4)
+    ap.add_argument("--heads", type=int, default=4)
+    ap.add_argument("--mask-ratio", type=float, default=0.5, dest="mask_ratio")
+    ap.add_argument("--lr", type=float, default=1.5e-4)
+    ap.add_argument("--warmup", type=int, default=10)
+    ap.add_argument("--device", default="cpu")
+    ap.add_argument("--amp", action="store_true", help="mixed precision (GPU)")
+    ap.add_argument("--dataset-len", type=int, default=512, dest="dataset_len")
+    ap.add_argument("--out", default="checkpoints", dest="out_dir")
+    ap.add_argument("--name", default="s2-biosignal-encoder")
+    ap.add_argument("--version", default="0.1.0")
+    ap.add_argument("--register", action="store_true",
+                    help="version the checkpoint in the model registry")
+    ap.add_argument("--commit", default="", dest="code_commit")
+    ap.add_argument("--mimic-dir", default=None, dest="mimic_dir",
+                    help="MIMIC-IV demo root (e.g. ~/aman-data/mimic-iv-demo/2.2); "
+                         "omit for synthetic data")
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args(argv)
+
+    run_training(
+        _build_cfg(args),
+        steps=args.steps, batch_size=args.batch_size, lr=args.lr,
+        warmup=args.warmup, device=args.device, amp=args.amp,
+        dataset_len=args.dataset_len, out_dir=args.out_dir, version=args.version,
+        name=args.name, register=args.register, code_commit=args.code_commit,
+        mimic_dir=args.mimic_dir, seed=args.seed,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/ml_engine/biosignal/train.py
+++ b/backend/ml_engine/biosignal/train.py
@@ -5,18 +5,23 @@ masked-timestep reconstruction objective and versions the resulting
 checkpoint in the model registry (mirrors
 :mod:`ml_engine.encoder.train`'s Stage-A loop for the 3D MRI encoder).
 
-Scaffold caveats (deliberately explicit — do not mistake this for a clinically
-meaningful HRV model):
-  * Real data is MIMIC-IV *demo* ICU ``chartevents`` — hourly-resampled vitals
-    (HR, RR, SpO2, NIBP), **not** continuous PPG/ECG waveforms. See
-    :mod:`ml_engine.ingestion.ehr`'s docstring for what would be needed for
-    true HRV (credentialed MIMIC Waveform DB / MIMIC-IV-ECG).
+Two real MIMIC data sources are supported, at different scope/fidelity
+(deliberately explicit — do not mistake either for a clinically validated
+HRV model):
+  * ``--mimic-dir`` (:class:`EhrVitalsDataset`) — MIMIC-IV *demo* ICU
+    ``chartevents``: hourly-resampled vitals (HR, RR, SpO2, NIBP), **not**
+    continuous waveforms. See :mod:`ml_engine.ingestion.ehr`'s docstring.
+  * ``--ecg-dir`` (:class:`EcgWaveformDataset`) — the open **MIMIC-IV-ECG
+    Demo**: genuine 12-lead, 500 Hz, 10 s waveforms (92 patients). Real
+    R-peak-derived HRV, still demo-scale. See
+    :mod:`ml_engine.ingestion.ecg`'s docstring for what the *full*
+    credentialed MIMIC-IV-ECG corpus would additionally unlock.
   * Every MIMIC-derived checkpoint registers with ``license_cleared=False``
     and is never a production candidate (D10/D11,
     ``docs/mimic-data-strategy.md`` §6).
   * ``SyntheticVitalsWindows`` keeps the loop runnable without any data
-    download at all (e.g. CI); swap in ``--mimic-dir`` for the real demo data,
-    nothing else in the loop changes.
+    download at all (e.g. CI); swap in ``--mimic-dir``/``--ecg-dir`` for real
+    data — nothing else in the loop changes.
 """
 from __future__ import annotations
 
@@ -82,6 +87,36 @@ class EhrVitalsDataset(Dataset):
         return self.windows[idx]
 
 
+class EcgWaveformDataset(Dataset):
+    """Real MIMIC-IV-ECG demo waveforms (see :mod:`ml_engine.ingestion.ecg`).
+
+    Genuine continuous 12-lead ECG, unlike ``EhrVitalsDataset``'s
+    hourly-charted vitals proxy — closer to what "PPG/ECG/HRV" literally
+    means, still demo-scale (92 patients, single 10 s strip each). Use a
+    ``cfg`` with ``in_channels=12`` (leads) and ``seq_len`` matching the
+    record length (500 Hz * 10 s = 5000 samples by default in the v0.1 demo).
+    """
+
+    def __init__(self, ecg_dir: str, cfg: BiosignalEncoderConfig, **load_kwargs: Any):
+        from ..ingestion.ecg import load_ecg_windows, normalise_windows
+        windows, manifests = load_ecg_windows(ecg_dir, **load_kwargs)
+        if windows.shape[1] != cfg.in_channels or windows.shape[2] != cfg.seq_len:
+            raise ValueError(
+                f"cfg (in_channels={cfg.in_channels}, seq_len={cfg.seq_len}) does not "
+                f"match loaded ECG windows {windows.shape[1:]} (leads, samples)"
+            )
+        self.windows = torch.from_numpy(normalise_windows(windows))
+        self.manifests = manifests
+        self.hrv_sdnn_ms = [m.hrv_sdnn_ms for m in manifests]
+        self.data_source = f"mimic-ecg:{ecg_dir} ({len(manifests)} records)"
+
+    def __len__(self) -> int:
+        return len(self.windows)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        return self.windows[idx]
+
+
 # --------------------------------------------------------------------------- #
 # Schedule
 # --------------------------------------------------------------------------- #
@@ -115,6 +150,7 @@ def run_training(
     register: bool = False,
     code_commit: str = "",
     mimic_dir: str | None = None,
+    ecg_dir: str | None = None,
     dataset: Dataset | None = None,
     seed: int = 0,
 ) -> dict[str, Any]:
@@ -128,6 +164,9 @@ def run_training(
         # Caller-supplied dataset (e.g. tests probing a specific cohort).
         ds = dataset
         data_source = getattr(dataset, "data_source", f"custom:{type(dataset).__name__}")
+    elif ecg_dir:
+        ds = EcgWaveformDataset(ecg_dir, cfg)
+        data_source = ds.data_source
     elif mimic_dir:
         ds = EhrVitalsDataset(mimic_dir, cfg)
         data_source = ds.data_source
@@ -227,7 +266,7 @@ def run_training(
 
 def _build_cfg(args: argparse.Namespace) -> BiosignalEncoderConfig:
     return BiosignalEncoderConfig(
-        seq_len=args.seq_len, patch_size=args.patch_size,
+        in_channels=args.in_channels, seq_len=args.seq_len, patch_size=args.patch_size,
         embed_dim=args.embed_dim, depth=args.depth, num_heads=args.heads,
         mask_ratio=args.mask_ratio,
     )
@@ -239,7 +278,10 @@ def main(argv: list[str] | None = None) -> int:
         description="SSL pretrain the S2 biosignal encoder on MIMIC ICU vitals (SCRUM-68)")
     ap.add_argument("--steps", type=int, default=100)
     ap.add_argument("--batch-size", type=int, default=8, dest="batch_size")
-    ap.add_argument("--seq-len", type=int, default=24, dest="seq_len")
+    ap.add_argument("--in-channels", type=int, default=5, dest="in_channels",
+                    help="5 for MIMIC vitals (--mimic-dir); 12 for ECG leads (--ecg-dir)")
+    ap.add_argument("--seq-len", type=int, default=24, dest="seq_len",
+                    help="24 hourly steps for vitals; 5000 samples (500Hz*10s) for ECG")
     ap.add_argument("--patch-size", type=int, default=4, dest="patch_size")
     ap.add_argument("--embed-dim", type=int, default=128, dest="embed_dim")
     ap.add_argument("--depth", type=int, default=4)
@@ -258,7 +300,10 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--commit", default="", dest="code_commit")
     ap.add_argument("--mimic-dir", default=None, dest="mimic_dir",
                     help="MIMIC-IV demo root (e.g. ~/aman-data/mimic-iv-demo/2.2); "
-                         "omit for synthetic data")
+                         "vitals proxy, use with defaults (--in-channels 5 --seq-len 24)")
+    ap.add_argument("--ecg-dir", default=None, dest="ecg_dir",
+                    help="MIMIC-IV-ECG demo root (e.g. ~/aman-data/mimic-iv-ecg-demo/...-0.1); "
+                         "real waveforms, use with --in-channels 12 --seq-len 5000")
     ap.add_argument("--seed", type=int, default=0)
     args = ap.parse_args(argv)
 
@@ -268,7 +313,7 @@ def main(argv: list[str] | None = None) -> int:
         warmup=args.warmup, device=args.device, amp=args.amp,
         dataset_len=args.dataset_len, out_dir=args.out_dir, version=args.version,
         name=args.name, register=args.register, code_commit=args.code_commit,
-        mimic_dir=args.mimic_dir, seed=args.seed,
+        mimic_dir=args.mimic_dir, ecg_dir=args.ecg_dir, seed=args.seed,
     )
     return 0
 

--- a/backend/ml_engine/ingestion/__init__.py
+++ b/backend/ml_engine/ingestion/__init__.py
@@ -1,14 +1,26 @@
-"""Compliant data ingestion (DICOM de-identification + standardisation; MIMIC EHR/vitals)."""
+"""Compliant data ingestion (DICOM de-identification + standardisation; MIMIC EHR/vitals/ECG)."""
 from .dicom import (
     IngestionManifest, deidentify, has_phi, load_series, pseudonymise, series_to_volume,
 )
+from .ecg import (
+    EcgIngestionManifest,
+    compute_hrv,
+    detect_r_peaks,
+    load_ecg_windows,
+    normalise_windows as ecg_normalise_windows,
+    pseudonymise as ecg_pseudonymise,
+)
 from .ehr import (
-    EhrIngestionManifest, load_vitals_windows, normalise_windows,
+    EhrIngestionManifest,
+    load_vitals_windows,
+    normalise_windows as ehr_normalise_windows,
     pseudonymise as ehr_pseudonymise,
 )
 
 __all__ = [
     "IngestionManifest", "deidentify", "has_phi", "load_series",
     "pseudonymise", "series_to_volume",
-    "EhrIngestionManifest", "load_vitals_windows", "normalise_windows", "ehr_pseudonymise",
+    "EhrIngestionManifest", "load_vitals_windows", "ehr_normalise_windows", "ehr_pseudonymise",
+    "EcgIngestionManifest", "load_ecg_windows", "ecg_normalise_windows", "ecg_pseudonymise",
+    "compute_hrv", "detect_r_peaks",
 ]

--- a/backend/ml_engine/ingestion/__init__.py
+++ b/backend/ml_engine/ingestion/__init__.py
@@ -1,9 +1,14 @@
-"""Compliant data ingestion (DICOM de-identification + standardisation)."""
+"""Compliant data ingestion (DICOM de-identification + standardisation; MIMIC EHR/vitals)."""
 from .dicom import (
     IngestionManifest, deidentify, has_phi, load_series, pseudonymise, series_to_volume,
+)
+from .ehr import (
+    EhrIngestionManifest, load_vitals_windows, normalise_windows,
+    pseudonymise as ehr_pseudonymise,
 )
 
 __all__ = [
     "IngestionManifest", "deidentify", "has_phi", "load_series",
     "pseudonymise", "series_to_volume",
+    "EhrIngestionManifest", "load_vitals_windows", "normalise_windows", "ehr_pseudonymise",
 ]

--- a/backend/ml_engine/ingestion/ecg.py
+++ b/backend/ml_engine/ingestion/ecg.py
@@ -1,0 +1,165 @@
+"""MIMIC-IV-ECG ingestion + real HRV feature extraction (SCRUM-68, S2).
+
+Closes a gap flagged in :mod:`ml_engine.ingestion.ehr`'s docstring: that module
+ingests only intermittently *charted* ICU vitals (no continuous waveform).
+This module reads the actual **MIMIC-IV-ECG Demo** —
+https://physionet.org/content/mimic-iv-ecg-demo/0.1/ — an ODbL, no-DUA open
+subset (verified: PhysioNet page confirms "Open Data Commons Open Database
+License v1.0"; no credentialing required). It contains 659 twelve-lead,
+500 Hz, 10-second diagnostic ECGs across 92 patients overlapping the MIMIC-IV
+Clinical Database Demo cohort — genuine continuous waveform data, so real
+(if short-window) R-peak-derived HRV (SDNN, RMSSD) is possible, unlike the
+vitals proxy in ``ingestion.ehr``.
+
+Scope honesty: this is still a *demo* subset (92 patients, single 10 s strip
+each) of the forthcoming full, **credentialed** MIMIC-IV-ECG module — fine for
+R&D pretraining and an honest small-sample HRV sanity check, not a clinical
+HRV study. ``license_cleared`` stays ``False`` for anything trained on it
+(D10/D11, ``docs/mimic-data-strategy.md``).
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+@dataclass
+class EcgIngestionManifest:
+    """Provenance for one ingested ECG record (feeds registry ``DataProvenance``).
+
+    Field-for-field analogue of
+    :class:`ml_engine.ingestion.dicom.IngestionManifest` /
+    :class:`ml_engine.ingestion.ehr.EhrIngestionManifest`.
+    """
+
+    pseudo_id: str                        # salted hash of the MIMIC subject_id
+    record_id: str = ""
+    leads: tuple[str, ...] = ()
+    fs: float = 0.0
+    n_samples: int = 0
+    hrv_sdnn_ms: float = float("nan")     # real R-peak-derived HRV (single 10s strip)
+    hrv_rmssd_ms: float = float("nan")
+    mean_hr_bpm: float = float("nan")
+    deidentified: bool = True             # MIMIC ships pre-deidentified
+    license_cleared: bool = False         # never True for MIMIC-derived data
+    source: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def pseudonymise(subject_id: Any, salt: str = "aman-ecg") -> str:
+    return hashlib.sha256(f"{salt}:{subject_id}".encode()).hexdigest()[:16]
+
+
+def detect_r_peaks(ecg_lead: np.ndarray, fs: float) -> np.ndarray:
+    """Lightweight Pan-Tompkins-style QRS detector (bandpass + derivative +
+    moving-window integration + peak-picking).
+
+    Not a clinical-grade detector — good enough to derive an honest,
+    order-of-magnitude HRV estimate from a single ~10 s strip; a real product
+    HRV feature would use a validated detector (e.g. ``neurokit2``) and
+    multi-minute recordings.
+    """
+    from scipy.signal import butter, filtfilt, find_peaks
+
+    nyq = fs / 2.0
+    b, a = butter(3, [5 / nyq, 15 / nyq], btype="band")
+    filtered = filtfilt(b, a, ecg_lead)
+    derivative = np.diff(filtered, prepend=filtered[0])
+    squared = derivative ** 2
+    window = max(1, int(0.15 * fs))
+    integrated = np.convolve(squared, np.ones(window) / window, mode="same")
+
+    min_distance = max(1, int(0.3 * fs))    # refractory period, caps ~200 bpm
+    peak_height = 0.35 * integrated.max() if integrated.max() > 0 else 0.0
+    peaks, _ = find_peaks(integrated, height=peak_height, distance=min_distance)
+    return peaks
+
+
+def compute_hrv(r_peaks: np.ndarray, fs: float) -> dict[str, float]:
+    """SDNN / RMSSD (ms) + mean heart rate (bpm) from R-peak sample indices."""
+    if len(r_peaks) < 3:
+        return {"sdnn_ms": float("nan"), "rmssd_ms": float("nan"), "mean_hr_bpm": float("nan")}
+    rr_ms = np.diff(r_peaks) / fs * 1000.0
+    return {
+        "sdnn_ms": float(np.std(rr_ms, ddof=1)),
+        "rmssd_ms": float(np.sqrt(np.mean(np.diff(rr_ms) ** 2))),
+        "mean_hr_bpm": float(60000.0 / np.mean(rr_ms)),
+    }
+
+
+def _find_lead_index(sig_names: list[str], preferred: tuple[str, ...]) -> int:
+    for name in preferred:
+        if name in sig_names:
+            return sig_names.index(name)
+    return 0
+
+
+def load_ecg_windows(
+    ecg_dir: str | Path,
+    *,
+    max_records: int | None = None,
+    hrv_lead_preference: tuple[str, ...] = ("II", "V5", "I"),
+) -> tuple[np.ndarray, list[EcgIngestionManifest]]:
+    """MIMIC-IV-ECG demo WFDB records -> ``(N, n_leads, n_samples)`` waveforms + manifests.
+
+    Every demo record is a fixed 12-lead, 500 Hz, 10 s strip, so no
+    resampling is needed (unlike the variable-length ICU vitals in
+    ``ingestion.ehr``); records are truncated to the shortest length present
+    before stacking, as a defensive measure. R-peaks are detected on one
+    clinically-standard lead per record (limb lead II preferred) to attach
+    real HRV features to the manifest — informational provenance, not an SSL
+    target.
+    """
+    import wfdb
+
+    ecg_dir = Path(ecg_dir)
+    records_file = ecg_dir / "RECORDS"
+    rel_paths = [line.strip() for line in records_file.read_text().splitlines() if line.strip()]
+    if max_records:
+        rel_paths = rel_paths[:max_records]
+
+    windows: list[np.ndarray] = []
+    manifests: list[EcgIngestionManifest] = []
+    for rel in rel_paths:
+        record = wfdb.rdrecord(str(ecg_dir / rel))
+        sig = np.nan_to_num(record.p_signal.T, nan=0.0).astype("float32")  # (n_leads, n_samples)
+
+        lead_idx = _find_lead_index(record.sig_name, hrv_lead_preference)
+        peaks = detect_r_peaks(sig[lead_idx], record.fs)
+        hrv = compute_hrv(peaks, record.fs)
+
+        # rel looks like "files/p10000032/s100780919/100780919"
+        subject_dir = Path(rel).parts[1] if len(Path(rel).parts) > 1 else ""
+        subject_id = subject_dir.lstrip("p")
+
+        manifests.append(EcgIngestionManifest(
+            pseudo_id=pseudonymise(subject_id),
+            record_id=Path(rel).name,
+            leads=tuple(record.sig_name),
+            fs=float(record.fs),
+            n_samples=sig.shape[1],
+            hrv_sdnn_ms=hrv["sdnn_ms"],
+            hrv_rmssd_ms=hrv["rmssd_ms"],
+            mean_hr_bpm=hrv["mean_hr_bpm"],
+            source=f"mimic-iv-ecg-demo:{ecg_dir.name}",
+        ))
+        windows.append(sig)
+
+    if not windows:
+        raise ValueError(f"no ECG records found under {ecg_dir}")
+    min_len = min(w.shape[1] for w in windows)
+    stacked = np.stack([w[:, :min_len] for w in windows])
+    return stacked, manifests
+
+
+def normalise_windows(windows: np.ndarray) -> np.ndarray:
+    """Per-lead z-score fit across the whole loaded cohort, applied to all."""
+    mu = windows.mean(axis=(0, 2), keepdims=True)
+    sigma = windows.std(axis=(0, 2), keepdims=True) + 1e-6
+    return ((windows - mu) / sigma).astype("float32")

--- a/backend/ml_engine/ingestion/ehr.py
+++ b/backend/ml_engine/ingestion/ehr.py
@@ -1,0 +1,146 @@
+"""EHR-vitals ingestion for MIMIC-derived S2 biosignal pretraining (SCRUM-65/68).
+
+Mirrors :mod:`ml_engine.ingestion.dicom`'s contract (manifest + hard-coded
+``license_cleared=False``) for a different source modality, per
+``docs/mimic-data-strategy.md`` §4: "New ingestion adapter alongside the DICOM
+one ... emits the same ``IngestionManifest``/``DataProvenance`` shape".
+
+Honesty note (read before wiring this into anything downstream): the **MIMIC-IV
+Clinical Database Demo** (ODbL, no DUA — the only MIMIC tier downloaded so far,
+see the SCRUM-64 provenance note) carries only intermittently *charted* ICU
+vitals in ``icu/chartevents`` — heart rate, respiratory rate, SpO2, and
+non-invasive blood pressure sampled roughly hourly by nursing staff. It does
+**not** contain continuous PPG/ECG waveforms. True beat-to-beat HRV (SDNN,
+RMSSD) requires the separate, fully-*credentialed* MIMIC Waveform Database /
+MIMIC-IV-ECG corpora (CITI + signed DUA, per Phase 4 in the data strategy) —
+out of scope until that access is acquired. What this module actually produces
+is hourly-resampled multichannel vitals windows: a legitimate S2-*adjacent*
+pretraining signal (see data-strategy.md §3, "vitals (S2-adjacent)"), not HRV
+in the strict sense. Never promote a model trained on this to production
+(``license_cleared`` stays ``False``; D10/D11).
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+# MIMIC-IV icu.d_items itemids for routine ICU vitals — verified against the
+# v2.2 Clinical Database Demo's icu/d_items.csv.gz (category "Routine Vital
+# Signs" / "Respiratory").
+VITAL_ITEMS: dict[str, int] = {
+    "heart_rate": 220045,
+    "resp_rate": 220210,
+    "spo2": 220277,
+    "nibp_systolic": 220179,
+    "nibp_diastolic": 220180,
+}
+
+
+@dataclass
+class EhrIngestionManifest:
+    """Provenance for one ingested ICU stay (feeds registry ``DataProvenance``).
+
+    Field-for-field analogue of
+    :class:`ml_engine.ingestion.dicom.IngestionManifest` so EHR-derived and
+    DICOM-derived data both plug into the same registry shape.
+    """
+
+    pseudo_id: str                        # salted hash of subject_id
+    stay_id: int = 0
+    channels: tuple[str, ...] = ()
+    n_timesteps: int = 0
+    resample_freq: str = "1h"
+    deidentified: bool = True             # MIMIC ships pre-deidentified
+    license_cleared: bool = False         # never True for MIMIC-derived data
+    source: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def pseudonymise(subject_id: Any, salt: str = "aman-ehr") -> str:
+    return hashlib.sha256(f"{salt}:{subject_id}".encode()).hexdigest()[:16]
+
+
+def load_vitals_windows(
+    mimic_dir: str | Path,
+    *,
+    channels: tuple[str, ...] = tuple(VITAL_ITEMS),
+    resample_freq: str = "1h",
+    window_steps: int = 24,
+    min_coverage: float = 0.5,
+    max_stays: int | None = None,
+) -> tuple[np.ndarray, list[EhrIngestionManifest]]:
+    """MIMIC ICU ``chartevents`` -> fixed-length vitals windows + manifests.
+
+    For each ICU stay: pivot the requested channels onto a regular
+    ``resample_freq`` grid (mean per bin), keep stays where the pre-interpolation
+    bin coverage is at least ``min_coverage``, gap-fill by interpolation, then
+    take the first ``window_steps`` bins. Stays with any channel entirely
+    missing, or shorter than ``window_steps``, are dropped.
+
+    Returns ``(windows, manifests)``: ``windows`` is
+    ``(N, len(channels), window_steps)`` float32 (un-normalised — see
+    :func:`normalise_windows`); ``manifests[i]`` describes ``windows[i]``.
+    """
+    mimic_dir = Path(mimic_dir)
+    icu = mimic_dir / "icu"
+    itemids = [VITAL_ITEMS[c] for c in channels]
+
+    ce = pd.read_csv(
+        icu / "chartevents.csv.gz", compression="gzip",
+        usecols=["subject_id", "stay_id", "itemid", "charttime", "valuenum"],
+    )
+    ce = ce[ce["itemid"].isin(itemids)].copy()
+    ce["charttime"] = pd.to_datetime(ce["charttime"])
+    item_to_channel = {v: k for k, v in VITAL_ITEMS.items()}
+    ce["channel"] = ce["itemid"].map(item_to_channel)
+
+    windows: list[np.ndarray] = []
+    manifests: list[EhrIngestionManifest] = []
+    stay_ids = sorted(ce["stay_id"].dropna().unique())
+    if max_stays:
+        stay_ids = stay_ids[:max_stays]
+
+    for stay_id in stay_ids:
+        stay = ce[ce["stay_id"] == stay_id]
+        subject_id = int(stay["subject_id"].iloc[0])
+        pivot = (
+            stay.pivot_table(index="charttime", columns="channel", values="valuenum", aggfunc="mean")
+            .reindex(columns=channels)
+        )
+        if pivot.empty:
+            continue
+        grid = pivot.resample(resample_freq).mean()
+        coverage = float(grid.notna().mean().mean())
+        if coverage < min_coverage or len(grid) < window_steps:
+            continue
+        grid = grid.interpolate(limit_direction="both")
+        if grid.isna().any().any():
+            continue  # a channel had zero readings for this stay -> can't fill
+        arr = grid.iloc[:window_steps].to_numpy(dtype="float32").T  # (C, T)
+        windows.append(arr)
+        manifests.append(EhrIngestionManifest(
+            pseudo_id=pseudonymise(subject_id),
+            stay_id=int(stay_id),
+            channels=tuple(channels),
+            n_timesteps=arr.shape[1],
+            resample_freq=resample_freq,
+            source=f"mimic-iv-demo:{mimic_dir.name}",
+        ))
+
+    if not windows:
+        raise ValueError(f"no ICU stays met coverage>={min_coverage} under {mimic_dir}")
+    return np.stack(windows), manifests
+
+
+def normalise_windows(windows: np.ndarray) -> np.ndarray:
+    """Per-channel z-score fit across the whole loaded cohort, applied to all."""
+    mu = windows.mean(axis=(0, 2), keepdims=True)
+    sigma = windows.std(axis=(0, 2), keepdims=True) + 1e-6
+    return ((windows - mu) / sigma).astype("float32")

--- a/backend/ml_engine/requirements.txt
+++ b/backend/ml_engine/requirements.txt
@@ -11,6 +11,8 @@
 
 # --- ingestion.ehr / biosignal (SCRUM-65/68, MIMIC) ---
 # pandas comes from backend/requirements.txt
+# wfdb>=4.1                 # ingestion.ecg: read MIMIC-IV-ECG WFDB waveform files
+# scipy                     # ingestion.ecg: R-peak detection (bandpass + peak-picking)
 
 # --- model training (heavy; GPU hosts) ---
 # torch>=2.3

--- a/backend/ml_engine/requirements.txt
+++ b/backend/ml_engine/requirements.txt
@@ -9,6 +9,9 @@
 # numpy, scikit-learn come from backend/requirements.txt
 # (optional, improves NLG eval): bert-score>=0.3.13
 
+# --- ingestion.ehr / biosignal (SCRUM-65/68, MIMIC) ---
+# pandas comes from backend/requirements.txt
+
 # --- model training (heavy; GPU hosts) ---
 # torch>=2.3
 # monai>=1.4

--- a/backend/ml_engine/tests/test_biosignal_train.py
+++ b/backend/ml_engine/tests/test_biosignal_train.py
@@ -4,6 +4,7 @@ Mirrors ``tests/test_encoder_train.py`` (the SCRUM-21 MRI encoder loop) for
 the S2 biosignal encoder: tiny config, a couple of CPU optimiser steps,
 finite/decreasing-capable loss, and a registry-compatible checkpoint.
 """
+import numpy as np
 import pytest
 
 torch = pytest.importorskip("torch")
@@ -12,7 +13,7 @@ pd = pytest.importorskip("pandas")
 from ml_engine.biosignal import BiosignalEncoder1D, BiosignalEncoderConfig
 from ml_engine.biosignal.model import patchify_1d
 from ml_engine.biosignal.train import (
-    EhrVitalsDataset, SyntheticVitalsWindows, cosine_warmup, run_training,
+    EcgWaveformDataset, EhrVitalsDataset, SyntheticVitalsWindows, cosine_warmup, run_training,
 )
 from ml_engine.ingestion.ehr import VITAL_ITEMS
 
@@ -81,3 +82,36 @@ def test_run_training_with_real_ehr_dataset(tmp_path):
     )
     assert summary["steps"] == 2
     assert "mimic-ehr" in summary["data"]
+
+
+def _write_demo_ecg_record(write_dir, record_name, n_leads=4, fs=100, n_samples=200, seed=0):
+    wfdb = pytest.importorskip("wfdb")
+    rng = np.random.default_rng(seed)
+    sig = rng.standard_normal((n_samples, n_leads))
+    wfdb.wrsamp(
+        record_name, fs=fs, units=["mV"] * n_leads, sig_name=[f"L{i}" for i in range(n_leads)],
+        p_signal=sig, fmt=["16"] * n_leads, write_dir=str(write_dir),
+    )
+
+
+def test_run_training_with_real_ecg_dataset(tmp_path):
+    pytest.importorskip("wfdb")
+    pytest.importorskip("scipy")
+    ecg_dir = tmp_path / "ecg-demo"
+    files = ecg_dir / "files" / "p1" / "s1"
+    files.mkdir(parents=True)
+    _write_demo_ecg_record(files, "rec0", n_leads=4, fs=100, n_samples=200)
+    (ecg_dir / "RECORDS").write_text("files/p1/s1/rec0\n")
+
+    cfg = BiosignalEncoderConfig(in_channels=4, seq_len=200, patch_size=20, embed_dim=16,
+                                 depth=2, num_heads=2)
+    ds = EcgWaveformDataset(str(ecg_dir), cfg)
+    assert len(ds) == 1
+    assert "mimic-ecg" in ds.data_source
+
+    summary = run_training(
+        cfg, steps=2, batch_size=1, warmup=1, device="cpu",
+        out_dir=tmp_path / "ckpt", log_every=1, register=False, seed=0, dataset=ds,
+    )
+    assert summary["steps"] == 2
+    assert "mimic-ecg" in summary["data"]

--- a/backend/ml_engine/tests/test_biosignal_train.py
+++ b/backend/ml_engine/tests/test_biosignal_train.py
@@ -1,0 +1,83 @@
+"""Smoke tests for the SCRUM-68 biosignal encoder SSL training loop.
+
+Mirrors ``tests/test_encoder_train.py`` (the SCRUM-21 MRI encoder loop) for
+the S2 biosignal encoder: tiny config, a couple of CPU optimiser steps,
+finite/decreasing-capable loss, and a registry-compatible checkpoint.
+"""
+import pytest
+
+torch = pytest.importorskip("torch")
+pd = pytest.importorskip("pandas")
+
+from ml_engine.biosignal import BiosignalEncoder1D, BiosignalEncoderConfig
+from ml_engine.biosignal.model import patchify_1d
+from ml_engine.biosignal.train import (
+    EhrVitalsDataset, SyntheticVitalsWindows, cosine_warmup, run_training,
+)
+from ml_engine.ingestion.ehr import VITAL_ITEMS
+
+
+def _tiny_cfg() -> BiosignalEncoderConfig:
+    return BiosignalEncoderConfig(seq_len=16, patch_size=4, embed_dim=16, depth=2, num_heads=2)
+
+
+def test_patchify_1d_shape_and_order():
+    cfg = _tiny_cfg()
+    x = torch.randn(3, cfg.in_channels, cfg.seq_len)
+    patches = patchify_1d(x, cfg.patch_size)
+    pv = cfg.patch_size * cfg.in_channels
+    assert patches.shape == (3, cfg.num_patches, pv)
+
+
+def test_cosine_warmup_monotonic_warmup_then_decay():
+    assert cosine_warmup(0, warmup=5, total=100) < cosine_warmup(4, warmup=5, total=100)
+    assert cosine_warmup(5, warmup=5, total=100) == pytest.approx(1.0, abs=1e-6)
+    assert cosine_warmup(99, warmup=5, total=100) < 0.05
+
+
+def test_run_training_smoke_writes_checkpoint(tmp_path):
+    summary = run_training(
+        _tiny_cfg(), steps=3, batch_size=2, warmup=1, dataset_len=8,
+        device="cpu", out_dir=tmp_path, log_every=1, register=False, seed=0,
+    )
+    assert summary["steps"] == 3
+    assert summary["final_loss"] == summary["final_loss"]      # not NaN
+    assert summary["data"] == "synthetic-placeholder"
+    ckpt = tmp_path / "s2-biosignal-encoder-0.1.0.pt"
+    assert ckpt.exists()
+    state = torch.load(ckpt, map_location="cpu", weights_only=False)
+    assert state["objective"] == "masked_biosignal_ssl"
+    enc = BiosignalEncoder1D(_tiny_cfg())
+    leftover = enc.load_pretrained(str(ckpt))
+    assert leftover == []        # full key match -> checkpoint is encoder-only
+
+
+def _write_demo_chartevents(mimic_dir, n_stays=3, n_hours=20):
+    icu = mimic_dir / "icu"
+    icu.mkdir(parents=True, exist_ok=True)
+    ts = pd.date_range("2026-01-01", periods=n_hours, freq="1h")
+    rows = []
+    for s in range(n_stays):
+        for hour_idx, t in enumerate(ts):
+            for ch_idx, ch in enumerate(VITAL_ITEMS):
+                value = 60.0 + 5.0 * ((hour_idx + ch_idx + s) % 4)
+                rows.append((s, 100 + s, VITAL_ITEMS[ch], t.isoformat(), value))
+    df = pd.DataFrame(rows, columns=["subject_id", "stay_id", "itemid", "charttime", "valuenum"])
+    df.to_csv(icu / "chartevents.csv.gz", index=False, compression="gzip")
+
+
+def test_run_training_with_real_ehr_dataset(tmp_path):
+    mimic_dir = tmp_path / "mimic-demo"
+    _write_demo_chartevents(mimic_dir, n_stays=3, n_hours=20)
+    cfg = BiosignalEncoderConfig(seq_len=16, patch_size=4, embed_dim=16, depth=2, num_heads=2)
+
+    ds = EhrVitalsDataset(str(mimic_dir), cfg)
+    assert len(ds) == 3
+    assert "mimic-ehr" in ds.data_source
+
+    summary = run_training(
+        cfg, steps=2, batch_size=2, warmup=1, device="cpu",
+        out_dir=tmp_path / "ckpt", log_every=1, register=False, seed=0, dataset=ds,
+    )
+    assert summary["steps"] == 2
+    assert "mimic-ehr" in summary["data"]

--- a/backend/ml_engine/tests/test_ingestion_ecg.py
+++ b/backend/ml_engine/tests/test_ingestion_ecg.py
@@ -1,0 +1,104 @@
+"""Tests for MIMIC-IV-ECG ingestion + HRV extraction (ml_engine.ingestion.ecg, SCRUM-68)."""
+import numpy as np
+import pytest
+
+wfdb = pytest.importorskip("wfdb")
+pytest.importorskip("scipy")
+
+from ml_engine.ingestion.ecg import (
+    compute_hrv, detect_r_peaks, load_ecg_windows, normalise_windows, pseudonymise,
+)
+
+
+def test_pseudonymise_is_deterministic_and_opaque():
+    a = pseudonymise("10000032")
+    assert a == pseudonymise("10000032")
+    assert "10000032" not in a and len(a) == 16
+
+
+def _synthetic_ecg_lead(fs=500, duration_s=10.0, hr_bpm=60.0, jitter=0.0, seed=0):
+    """A crude periodic-spike ECG stand-in with a known, controllable heart rate."""
+    rng = np.random.default_rng(seed)
+    n = int(fs * duration_s)
+    t = np.arange(n) / fs
+    signal = np.zeros(n)
+    rr_s = 60.0 / hr_bpm
+    beat_time = rr_s
+    while beat_time < duration_s:
+        jittered = beat_time + rng.normal(0, jitter)
+        idx = int(jittered * fs)
+        if 0 <= idx < n:
+            width = max(1, int(0.02 * fs))
+            lo, hi = max(0, idx - width), min(n, idx + width)
+            signal[lo:hi] += np.hanning(hi - lo) * 5.0
+        beat_time += rr_s
+    signal += 0.01 * rng.standard_normal(n)   # tiny sensor noise
+    return signal.astype("float32"), t
+
+
+def test_detect_r_peaks_recovers_known_heart_rate():
+    fs = 500
+    lead, _ = _synthetic_ecg_lead(fs=fs, hr_bpm=75.0, jitter=0.0)
+    peaks = detect_r_peaks(lead, fs)
+    hrv = compute_hrv(peaks, fs)
+    assert hrv["mean_hr_bpm"] == pytest.approx(75.0, abs=3.0)
+    assert hrv["sdnn_ms"] < 15.0   # near-perfectly regular beats -> low SDNN
+
+
+def test_compute_hrv_nan_below_three_peaks():
+    hrv = compute_hrv(np.array([0, 100]), fs=500.0)
+    assert all(v != v for v in hrv.values())  # all NaN
+
+
+def _write_demo_record(write_dir, record_name, n_leads=12, fs=500, seed=0):
+    rng = np.random.default_rng(seed)
+    duration_s = 10.0
+    leads = [f"L{i}" for i in range(n_leads)]
+    sig = np.stack([
+        _synthetic_ecg_lead(fs=fs, duration_s=duration_s, hr_bpm=70.0 + i, seed=seed + i)[0]
+        for i in range(n_leads)
+    ], axis=1)  # (n_samples, n_leads)
+    wfdb.wrsamp(
+        record_name, fs=fs, units=["mV"] * n_leads, sig_name=leads,
+        p_signal=sig.astype("float64"), fmt=["16"] * n_leads, write_dir=str(write_dir),
+    )
+
+
+def test_load_ecg_windows_shapes_and_provenance(tmp_path):
+    files = tmp_path / "files" / "p10000032" / "s100780919"
+    files.mkdir(parents=True)
+    _write_demo_record(files, "100780919", n_leads=12, fs=500, seed=0)
+    (tmp_path / "RECORDS").write_text("files/p10000032/s100780919/100780919\n")
+
+    windows, manifests = load_ecg_windows(tmp_path)
+
+    assert windows.shape == (1, 12, 5000)
+    assert len(manifests) == 1
+    m = manifests[0]
+    assert m.record_id == "100780919"
+    assert m.n_samples == 5000
+    assert m.fs == 500.0
+    assert m.deidentified is True
+    assert m.license_cleared is False
+    assert "10000032" not in m.pseudo_id
+    assert m.hrv_sdnn_ms == m.hrv_sdnn_ms  # not NaN -- R-peaks were found
+
+
+def test_load_ecg_windows_raises_when_empty(tmp_path):
+    (tmp_path / "RECORDS").write_text("")
+    with pytest.raises(ValueError):
+        load_ecg_windows(tmp_path)
+
+
+def test_normalise_windows_zero_mean_unit_std(tmp_path):
+    for i, (subj, stay) in enumerate([("p1", "s1"), ("p2", "s2")]):
+        files = tmp_path / "files" / subj / stay
+        files.mkdir(parents=True)
+        _write_demo_record(files, f"rec{i}", n_leads=3, fs=500, seed=i)
+    (tmp_path / "RECORDS").write_text(
+        "files/p1/s1/rec0\nfiles/p2/s2/rec1\n"
+    )
+    windows, _ = load_ecg_windows(tmp_path)
+    norm = normalise_windows(windows)
+    assert norm.mean(axis=(0, 2)) == pytest.approx([0.0] * 3, abs=1e-4)
+    assert norm.std(axis=(0, 2)) == pytest.approx([1.0] * 3, abs=1e-3)

--- a/backend/ml_engine/tests/test_ingestion_ehr.py
+++ b/backend/ml_engine/tests/test_ingestion_ehr.py
@@ -1,0 +1,85 @@
+"""Tests for MIMIC EHR-vitals ingestion (ml_engine.ingestion.ehr, SCRUM-65/68)."""
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from ml_engine.ingestion.ehr import (
+    VITAL_ITEMS, load_vitals_windows, normalise_windows, pseudonymise,
+)
+
+
+def _write_chartevents(mimic_dir, rows):
+    icu = mimic_dir / "icu"
+    icu.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame(rows, columns=["subject_id", "stay_id", "itemid", "charttime", "valuenum"])
+    df.to_csv(icu / "chartevents.csv.gz", index=False, compression="gzip")
+
+
+def _hourly_stay_rows(subject_id, stay_id, n_hours, channels=tuple(VITAL_ITEMS), start="2026-01-01"):
+    ts = pd.date_range(start, periods=n_hours, freq="1h")
+    rows = []
+    for hour_idx, t in enumerate(ts):
+        for ch_idx, ch in enumerate(channels):
+            value = 60.0 + 5.0 * ((hour_idx + ch_idx) % 4)   # deterministic, non-constant
+            rows.append((subject_id, stay_id, VITAL_ITEMS[ch], t.isoformat(), value))
+    return rows
+
+
+def test_pseudonymise_is_deterministic_and_opaque():
+    a = pseudonymise(12345)
+    assert a == pseudonymise(12345)
+    assert "12345" not in a and len(a) == 16
+
+
+def test_load_vitals_windows_shapes_and_provenance(tmp_path):
+    rows = _hourly_stay_rows(subject_id=1, stay_id=100, n_hours=30)
+    _write_chartevents(tmp_path, rows)
+
+    windows, manifests = load_vitals_windows(tmp_path, window_steps=24)
+
+    assert windows.shape == (1, len(VITAL_ITEMS), 24)
+    assert len(manifests) == 1
+    m = manifests[0]
+    assert m.stay_id == 100
+    assert m.n_timesteps == 24
+    assert m.deidentified is True
+    assert m.license_cleared is False          # never cleared for MIMIC-derived data
+    assert "12345" not in m.pseudo_id           # not the raw subject id, opaque hash
+
+
+def test_load_vitals_windows_drops_sparse_stay(tmp_path):
+    good = _hourly_stay_rows(subject_id=1, stay_id=100, n_hours=30)
+    # Sparse stay: only 2 charted hours out of a 30-hour span -> below min_coverage.
+    sparse_ts = list(pd.date_range("2026-01-01", periods=30, freq="1h"))
+    sparse = [
+        (2, 200, VITAL_ITEMS[ch], sparse_ts[i].isoformat(), 70.0)
+        for i, ch in zip((0, 29), list(VITAL_ITEMS)[:2])
+    ]
+    _write_chartevents(tmp_path, good + sparse)
+
+    windows, manifests = load_vitals_windows(tmp_path, window_steps=24, min_coverage=0.5)
+
+    assert len(manifests) == 1
+    assert manifests[0].stay_id == 100          # only the well-covered stay survives
+
+
+def test_load_vitals_windows_raises_when_nothing_qualifies(tmp_path):
+    rows = _hourly_stay_rows(subject_id=1, stay_id=100, n_hours=5)  # shorter than window_steps
+    _write_chartevents(tmp_path, rows)
+
+    with pytest.raises(ValueError):
+        load_vitals_windows(tmp_path, window_steps=24)
+
+
+def test_normalise_windows_zero_mean_unit_std(tmp_path):
+    rows = (
+        _hourly_stay_rows(subject_id=1, stay_id=100, n_hours=24)
+        + _hourly_stay_rows(subject_id=2, stay_id=200, n_hours=24, start="2026-02-01")
+    )
+    _write_chartevents(tmp_path, rows)
+    windows, _ = load_vitals_windows(tmp_path, window_steps=24)
+
+    norm = normalise_windows(windows)
+    assert norm.shape == windows.shape
+    assert norm.mean(axis=(0, 2)) == pytest.approx([0.0] * len(VITAL_ITEMS), abs=1e-5)
+    assert norm.std(axis=(0, 2)) == pytest.approx([1.0] * len(VITAL_ITEMS), abs=1e-4)

--- a/docs/biosignal-scrum-68.md
+++ b/docs/biosignal-scrum-68.md
@@ -1,8 +1,9 @@
-# SCRUM-68 — S2 Biosignal Encoder: SSL Pretraining on MIMIC ICU Vitals
+# SCRUM-68 — S2 Biosignal Encoder: SSL Pretraining on MIMIC Vitals + ECG
 
 Epic: SCRUM-63 (MIMIC integration), Phase 3 of `docs/mimic-data-strategy.md`.
 Depends on the SCRUM-64 Phase-0 gate (merged, PR #43). Code:
-`backend/ml_engine/ingestion/ehr.py`, `backend/ml_engine/biosignal/`.
+`backend/ml_engine/ingestion/ehr.py`, `backend/ml_engine/ingestion/ecg.py`,
+`backend/ml_engine/biosignal/`.
 
 ## Goal
 
@@ -10,90 +11,138 @@ A pretraining scaffold for the S2 service's (team Mukhammedzhan) eventual
 wearable-PPG/ECG encoder, using MIMIC-IV as an R&D/pretraining feed per the
 data strategy — never a production-eligible model (D10/D11).
 
-## Data reality check (read first)
+## Data reality check (read first — corrected from the first pass)
 
-The only MIMIC tier downloaded so far is the **Clinical Database Demo**
-(v2.2, ODbL, no DUA — the SCRUM-64 provenance note). It contains:
+Two MIMIC tiers are now downloaded, at different fidelity:
 
-- `icu/chartevents` — **intermittently charted vitals** (heart rate,
-  respiratory rate, SpO2, non-invasive blood pressure), sampled roughly
-  hourly by nursing staff.
-- **No continuous PPG/ECG waveforms.** No `MIMIC-IV-ECG`, no MIMIC Waveform
-  Database. Both are separate, fully-*credentialed* PhysioNet projects
-  (CITI + signed DUA — Phase 4 in the data strategy), not yet acquired.
-- **No `MIMIC-IV-Note`** either (discharge/radiology text) — also a separate
-  credentialed project with no open demo tier found. The "MIMIC-Note NLP
-  eval" half of the Phase-3 scope in the roadmap is **blocked on that
-  acquisition decision**, not implemented here; see Follow-Ups.
+- **MIMIC-IV Clinical Database Demo** (v2.2, ODbL, no DUA — SCRUM-64). Its
+  `icu/chartevents` gives only **intermittently charted vitals** (heart rate,
+  respiratory rate, SpO2, NIBP), sampled roughly hourly by nursing staff —
+  no continuous waveform.
+- **MIMIC-IV-ECG Demo** (v0.1, **also ODbL, also no DUA** — verified directly
+  against the PhysioNet project page, not assumed). This *does* carry genuine
+  continuous waveform: 659 twelve-lead, 500 Hz, 10-second diagnostic ECGs
+  across 92 patients overlapping the Clinical Database Demo cohort. **This
+  corrects the initial version of this doc**, which stated no open-access
+  continuous waveform existed — it does, as a small matched-subset demo of
+  the forthcoming full (credentialed) `MIMIC-IV-ECG` module. Downloaded and
+  checksum-verified (1321/1321 files OK); provenance note at
+  `~/aman-data/mimic-iv-ecg-demo/DATA_PROVENANCE.md`.
+- **Still not available:** `MIMIC-IV-Note` (discharge/radiology text) has
+  **no open demo tier** — confirmed directly against its PhysioNet page
+  (`PhysioNet Credentialed Health Data License 1.5.0`, CITI + signed DUA
+  required, no exception). The "MIMIC-Note NLP eval" half of the Phase-3
+  roadmap item remains **blocked on a credentialing/legal decision**, not
+  implemented here — building a fake eval against non-existent text would
+  violate this project's "demo framing is honest" convention.
 
-So this milestone is honestly scoped as **vitals-time-series pretraining**,
-not HRV in the strict beat-to-beat sense. That's a real, legitimate S2-adjacent
-signal (data-strategy.md §3 calls out ICU `chartevents` explicitly), just not
-what "PPG/ECG/HRV" implies at face value.
+Net: this milestone now covers two honestly-scoped tiers — coarse
+**vitals-time-series pretraining** (real signal, not real HRV) *and*
+genuine **ECG-waveform pretraining with real R-peak-derived HRV** (real
+signal, but still demo-scale: 92 patients, single 10 s strip each, not a
+clinical HRV study).
 
 ## Design
 
-- `ingestion/ehr.py` — MIMIC `icu/chartevents` → per-ICU-stay windows.
-  Pivots 5 channels (`heart_rate`, `resp_rate`, `spo2`, `nibp_systolic`,
-  `nibp_diastolic`) onto an hourly grid, drops stays below a coverage
-  threshold, gap-fills by interpolation, and emits `EhrIngestionManifest` —
-  the same shape as `ingestion/dicom.py`'s `IngestionManifest`
-  (`deidentified=True`, `license_cleared=False` always).
+- `ingestion/ehr.py` — MIMIC `icu/chartevents` → per-ICU-stay hourly vitals
+  windows (5 channels). Emits `EhrIngestionManifest`.
+- `ingestion/ecg.py` — MIMIC-IV-ECG demo WFDB records → `(leads, samples)`
+  waveforms. Runs a lightweight Pan-Tompkins-style R-peak detector (bandpass
+  + derivative + moving-window integration + peak-picking, `scipy`) per
+  record and attaches real SDNN/RMSSD/mean-HR to `EcgIngestionManifest` —
+  informational provenance, not an SSL target. Not clinical-grade (single
+  short strip, simple detector).
+- Both manifests are field-for-field analogues of `ingestion/dicom.py`'s
+  `IngestionManifest` (`deidentified=True`, `license_cleared=False` always).
 - `biosignal/model.py` — `BiosignalEncoder1D`: a small 1D-patch ViT
   (`Conv1d` patch embed → cls token + positional embeddings →
-  `TransformerEncoder`). `MaskedBiosignalSSL` reapplies the MRI encoder's
-  SimMIM recipe (decision D15: mask at the input, not after the forward
-  pass) to vitals windows.
+  `TransformerEncoder`), generic over channel count / sequence length so the
+  same architecture serves both data tiers. `MaskedBiosignalSSL` reapplies
+  the MRI encoder's SimMIM recipe (decision D15: mask at the input, not
+  after the forward pass).
 - `biosignal/train.py` — training loop mirroring `encoder/train.py`:
-  `SyntheticVitalsWindows` (no-download placeholder) or `EhrVitalsDataset`
-  (real MIMIC demo data via `--mimic-dir`); registers checkpoints in the
-  model registry under `stage="biosignal_encoder"`.
+  `SyntheticVitalsWindows` (no-download placeholder), `EhrVitalsDataset`
+  (`--mimic-dir`), or `EcgWaveformDataset` (`--ecg-dir`); registers
+  checkpoints under `stage="biosignal_encoder"`.
 
-## Real run (MIMIC-IV demo, CPU)
+## Real runs (CPU)
+
+**Vitals** (`s2-biosignal-encoder:0.1.0`):
 
 ```bash
-python -m ml_engine.biosignal.train \
-    --mimic-dir ~/aman-data/mimic-iv-demo/2.2 \
+python -m ml_engine.biosignal.train --mimic-dir ~/aman-data/mimic-iv-demo/2.2 \
     --steps 50 --batch-size 8 --warmup 5 --device cpu --register
 ```
 
 116 ICU stays met the coverage threshold (24-hour windows, 5 channels).
-Loss decreased monotonically over 50 steps (`1.057 → 0.631`), confirming the
-masked-reconstruction objective is a real learning signal on real MIMIC data,
-not just shape-checked. Registered as `s2-biosignal-encoder:0.1.0`,
-`data.license_cleared=False`.
+Loss decreased monotonically over 50 steps (`1.057 → 0.631`).
+
+**ECG** (`s2-ecg-encoder:0.1.1`):
+
+```bash
+python -m ml_engine.biosignal.train \
+    --ecg-dir ~/aman-data/mimic-iv-ecg-demo/mimic-iv-ecg-demo-diagnostic-electrocardiogram-matched-subset-demo-0.1 \
+    --in-channels 12 --seq-len 5000 --patch-size 50 --embed-dim 64 --depth 2 --heads 4 \
+    --steps 300 --batch-size 16 --warmup 20 --lr 3e-4 --device cpu --register
+```
+
+All 659 records loaded (12 leads × 5000 samples each) in ~3 s. Loss trends
+down but noisily over 300 steps (`1.045 → ~0.94`) — real learning, but
+markedly slower/noisier than the vitals run. That's expected, not a bug:
+raw 500 Hz ECG concentrates most of its energy in narrow, sharp QRS
+complexes, so masked-*amplitude* reconstruction is a harder objective on a
+small (659-window) dataset than smoothly-varying hourly vitals. Real R-peak
+detection on a representative record found **HR ≈ 91 bpm, SDNN ≈ 9.8 ms,
+RMSSD ≈ 9.4 ms** — plausible for a MIMIC ICU/ED cohort (tachycardic, low
+short-term variability), not cherry-picked (cohort-wide: mean HR ≈ 92 bpm,
+mean SDNN ≈ 71 ms, driven up by a few likely-arrhythmic/detector-noisy
+outliers — consistent with "simple detector, ICU population," not a
+validated clinical HRV claim).
 
 ## What Is Real
 
-- Full ingestion adapter, run against the actual downloaded MIMIC-IV demo
-  (not a mock) — 116 real ICU stays produce real windows.
+- Both ingestion adapters, run against actual downloaded MIMIC data (not
+  mocks) — 116 real ICU stays (vitals) and all 659 real ECG records.
+- Real R-peak detection and HRV computation on genuine waveform data — a
+  real (if simple, non-clinical-grade) signal-processing pipeline, not a
+  stub returning fixed numbers.
 - Full encoder + SimMIM-style SSL objective (PyTorch), same recipe already
-  validated for the MRI encoder (D15).
-- Registry integration: registers with the correct `stage`, `DataProvenance`
+  validated for the MRI encoder (D15), reused unmodified across both data
+  tiers via config alone (`in_channels`/`seq_len`).
+- Registry integration for both: correct `stage`, `DataProvenance`
   (`license_cleared=False`, dataset name recorded), never touches promotion
-  gates (R&D artifact only).
-- A real training run on real data, loss decreasing (not synthetic-only).
+  gates (R&D artifacts only).
+- Two real training runs on real data with decreasing loss (not
+  synthetic-only): vitals converges cleanly, ECG converges slowly/noisily —
+  reported as such, not smoothed over.
 
 ## What Is Mocked / Pending
 
 - `SyntheticVitalsWindows` is a CPU-only, no-download fallback for the
-  training loop (parallels `SyntheticMRIVolumes`), not a substitute for the
-  real MIMIC run above.
+  training loop (parallels `SyntheticMRIVolumes`), not a substitute for
+  either real run above.
 - No downstream probe yet (no labelled task to linear-probe against, unlike
-  the MRI encoder's IXI-based check) — there's no obvious label in the demo
-  tier to validate transfer against.
-- **MIMIC-Note NLP eval is not implemented.** No note-like free text exists
-  in the downloaded demo; building a fake eval against non-existent data
-  would violate this project's "demo framing is honest" convention.
+  the MRI encoder's IXI-based check) for either data tier.
+- **MIMIC-Note NLP eval is not implemented** — confirmed blocked (see Data
+  reality check), not attempted with fake data.
+- ECG pretraining converges slowly on this demo's 659 windows; the full
+  credentialed `MIMIC-IV-ECG` corpus (thousands of records) or a smarter SSL
+  target (e.g. reconstructing a filtered/derivative signal, or a contrastive
+  objective — common in real ECG-SSL literature) would likely help more than
+  further hyperparameter tuning on this small sample.
 
 ## Production Follow-Ups
 
-- Legal/owner decision on acquiring `MIMIC-IV-ECG` / the MIMIC Waveform DB
-  (credentialed) if true continuous-waveform HRV pretraining is wanted, or
-  on a `MIMIC-IV-Note`-equivalent source for the NLP-eval half.
-- A held-out downstream task (e.g. a chartevents-derived early-warning label)
-  to linear-probe the pretrained encoder against, mirroring
-  `encoder/linear_probe.py`'s beats-from-scratch check.
+- Legal/owner decision on acquiring the full credentialed `MIMIC-IV-ECG` /
+  MIMIC Waveform DB (much larger N, multi-minute recordings — real HRV, not
+  single-strip) or a `MIMIC-IV-Note`-equivalent source for the NLP-eval half.
+- A held-out downstream task to linear-probe both pretrained encoders
+  against, mirroring `encoder/linear_probe.py`'s beats-from-scratch check
+  (e.g. an ICU-mortality/early-warning label for vitals; an ECG-diagnosis
+  label if the full MIMIC-IV-ECG's paired diagnostic statements are acquired).
+- Consider a contrastive or filtered-target SSL objective for the ECG
+  encoder specifically, given the raw-amplitude masked-reconstruction result
+  above.
 - Swap in the real wearable PPG/ECG pipeline once S2 hardware data exists;
   the ingestion/training contracts (`IngestionManifest`-shaped manifest,
-  `--mimic-dir`-style swap) are designed to carry over.
+  `--mimic-dir`/`--ecg-dir`-style swap) are designed to carry over.

--- a/docs/biosignal-scrum-68.md
+++ b/docs/biosignal-scrum-68.md
@@ -1,0 +1,99 @@
+# SCRUM-68 — S2 Biosignal Encoder: SSL Pretraining on MIMIC ICU Vitals
+
+Epic: SCRUM-63 (MIMIC integration), Phase 3 of `docs/mimic-data-strategy.md`.
+Depends on the SCRUM-64 Phase-0 gate (merged, PR #43). Code:
+`backend/ml_engine/ingestion/ehr.py`, `backend/ml_engine/biosignal/`.
+
+## Goal
+
+A pretraining scaffold for the S2 service's (team Mukhammedzhan) eventual
+wearable-PPG/ECG encoder, using MIMIC-IV as an R&D/pretraining feed per the
+data strategy — never a production-eligible model (D10/D11).
+
+## Data reality check (read first)
+
+The only MIMIC tier downloaded so far is the **Clinical Database Demo**
+(v2.2, ODbL, no DUA — the SCRUM-64 provenance note). It contains:
+
+- `icu/chartevents` — **intermittently charted vitals** (heart rate,
+  respiratory rate, SpO2, non-invasive blood pressure), sampled roughly
+  hourly by nursing staff.
+- **No continuous PPG/ECG waveforms.** No `MIMIC-IV-ECG`, no MIMIC Waveform
+  Database. Both are separate, fully-*credentialed* PhysioNet projects
+  (CITI + signed DUA — Phase 4 in the data strategy), not yet acquired.
+- **No `MIMIC-IV-Note`** either (discharge/radiology text) — also a separate
+  credentialed project with no open demo tier found. The "MIMIC-Note NLP
+  eval" half of the Phase-3 scope in the roadmap is **blocked on that
+  acquisition decision**, not implemented here; see Follow-Ups.
+
+So this milestone is honestly scoped as **vitals-time-series pretraining**,
+not HRV in the strict beat-to-beat sense. That's a real, legitimate S2-adjacent
+signal (data-strategy.md §3 calls out ICU `chartevents` explicitly), just not
+what "PPG/ECG/HRV" implies at face value.
+
+## Design
+
+- `ingestion/ehr.py` — MIMIC `icu/chartevents` → per-ICU-stay windows.
+  Pivots 5 channels (`heart_rate`, `resp_rate`, `spo2`, `nibp_systolic`,
+  `nibp_diastolic`) onto an hourly grid, drops stays below a coverage
+  threshold, gap-fills by interpolation, and emits `EhrIngestionManifest` —
+  the same shape as `ingestion/dicom.py`'s `IngestionManifest`
+  (`deidentified=True`, `license_cleared=False` always).
+- `biosignal/model.py` — `BiosignalEncoder1D`: a small 1D-patch ViT
+  (`Conv1d` patch embed → cls token + positional embeddings →
+  `TransformerEncoder`). `MaskedBiosignalSSL` reapplies the MRI encoder's
+  SimMIM recipe (decision D15: mask at the input, not after the forward
+  pass) to vitals windows.
+- `biosignal/train.py` — training loop mirroring `encoder/train.py`:
+  `SyntheticVitalsWindows` (no-download placeholder) or `EhrVitalsDataset`
+  (real MIMIC demo data via `--mimic-dir`); registers checkpoints in the
+  model registry under `stage="biosignal_encoder"`.
+
+## Real run (MIMIC-IV demo, CPU)
+
+```bash
+python -m ml_engine.biosignal.train \
+    --mimic-dir ~/aman-data/mimic-iv-demo/2.2 \
+    --steps 50 --batch-size 8 --warmup 5 --device cpu --register
+```
+
+116 ICU stays met the coverage threshold (24-hour windows, 5 channels).
+Loss decreased monotonically over 50 steps (`1.057 → 0.631`), confirming the
+masked-reconstruction objective is a real learning signal on real MIMIC data,
+not just shape-checked. Registered as `s2-biosignal-encoder:0.1.0`,
+`data.license_cleared=False`.
+
+## What Is Real
+
+- Full ingestion adapter, run against the actual downloaded MIMIC-IV demo
+  (not a mock) — 116 real ICU stays produce real windows.
+- Full encoder + SimMIM-style SSL objective (PyTorch), same recipe already
+  validated for the MRI encoder (D15).
+- Registry integration: registers with the correct `stage`, `DataProvenance`
+  (`license_cleared=False`, dataset name recorded), never touches promotion
+  gates (R&D artifact only).
+- A real training run on real data, loss decreasing (not synthetic-only).
+
+## What Is Mocked / Pending
+
+- `SyntheticVitalsWindows` is a CPU-only, no-download fallback for the
+  training loop (parallels `SyntheticMRIVolumes`), not a substitute for the
+  real MIMIC run above.
+- No downstream probe yet (no labelled task to linear-probe against, unlike
+  the MRI encoder's IXI-based check) — there's no obvious label in the demo
+  tier to validate transfer against.
+- **MIMIC-Note NLP eval is not implemented.** No note-like free text exists
+  in the downloaded demo; building a fake eval against non-existent data
+  would violate this project's "demo framing is honest" convention.
+
+## Production Follow-Ups
+
+- Legal/owner decision on acquiring `MIMIC-IV-ECG` / the MIMIC Waveform DB
+  (credentialed) if true continuous-waveform HRV pretraining is wanted, or
+  on a `MIMIC-IV-Note`-equivalent source for the NLP-eval half.
+- A held-out downstream task (e.g. a chartevents-derived early-warning label)
+  to linear-probe the pretrained encoder against, mirroring
+  `encoder/linear_probe.py`'s beats-from-scratch check.
+- Swap in the real wearable PPG/ECG pipeline once S2 hardware data exists;
+  the ingestion/training contracts (`IngestionManifest`-shaped manifest,
+  `--mimic-dir`-style swap) are designed to carry over.


### PR DESCRIPTION
## Summary

- New `backend/ml_engine/ingestion/ehr.py`: loads MIMIC-IV demo ICU `chartevents` into hourly-resampled vitals windows (heart rate, resp rate, SpO2, NIBP sys/dia), emitting an `EhrIngestionManifest` that mirrors `dicom.py`'s `IngestionManifest` contract (`deidentified=True`, `license_cleared=False` always).
- New `backend/ml_engine/ingestion/ecg.py`: downloads/reads the **open MIMIC-IV-ECG Demo** (ODbL, no DUA — verified directly against the PhysioNet project page, 1321/1321 file checksums OK, kept outside the repo) — genuine 12-lead, 500 Hz, 10 s waveforms across 92 patients. Runs a lightweight Pan-Tompkins-style R-peak detector to attach real SDNN/RMSSD/mean-HR to each record's manifest. This corrects the PR's first-pass docs, which claimed no open continuous-waveform tier existed.
- New `backend/ml_engine/biosignal/` package: a 1D-patch ViT encoder (`BiosignalEncoder1D`) + SimMIM-style masked-timestep SSL objective (`MaskedBiosignalSSL`), reusing the MRI encoder's proven pretraining recipe (decision D15). `biosignal/train.py` supports both data tiers (`--mimic-dir` for vitals, `--ecg-dir` for ECG waveforms) via the same generic architecture, and registers checkpoints under `stage="biosignal_encoder"`.
- `docs/biosignal-scrum-68.md` documents both real runs: vitals (116 ICU stays, loss 1.057 → 0.631 over 50 CPU steps) and ECG (all 659 demo records, loss 1.045 → ~0.94 over 300 steps — reported honestly as slower/noisier than the vitals run, since raw 500 Hz ECG is a harder masked-reconstruction target on a small sample). Also confirms (not assumes) that `MIMIC-IV-Note` has no open demo tier, so the MIMIC-Note NLP-eval half of the Phase-3 roadmap item remains a documented, blocked follow-up rather than something faked against non-existent data.

## Test plan

- [x] `python -m pytest` in `backend/ml_engine` — 87 passed, 1 skipped (was 71 passed, 1 skipped before this PR; no regressions)
- [x] `tests/test_ingestion_ehr.py` (5 tests), `tests/test_ingestion_ecg.py` (6 tests, incl. R-peak detection recovering a known synthetic heart rate), `tests/test_biosignal_train.py` (5 tests, incl. training smoke tests against both real-shaped EHR and ECG datasets)
- [x] Manual real-data runs against both downloaded MIMIC demos:
  - `python -m ml_engine.biosignal.train --mimic-dir ~/aman-data/mimic-iv-demo/2.2 --steps 50 --register` → registers `s2-biosignal-encoder:0.1.0`
  - `python -m ml_engine.biosignal.train --ecg-dir ~/aman-data/mimic-iv-ecg-demo/... --in-channels 12 --seq-len 5000 --patch-size 50 --steps 300 --register` → registers `s2-ecg-encoder:0.1.1`